### PR TITLE
fixed Linux compilation, added Makefile

### DIFF
--- a/RigidCoupling/Makefile
+++ b/RigidCoupling/Makefile
@@ -1,0 +1,21 @@
+# Declaration of variables
+CC = g++ -O3
+CC_FLAGS = -w -I/usr/include/eigen3 -I/usr/include/eigen3/unsupported
+LD_FLAGS = -L/usr/lib -L/usr/local/lib -lGL -lGLU -lglut
+
+# File names
+EXEC = run
+SOURCES = $(wildcard ../*.cpp)
+OBJECTS = $(SOURCES:.cpp=.o)
+
+# Main target
+$(EXEC): $(OBJECTS)
+	$(CC) $(OBJECTS) -o $(EXEC) $(LD_FLAGS)
+
+# To obtain object files
+%.o: %.cpp
+	$(CC) -c $(CC_FLAGS) $< -o $@
+
+# To remove generated files
+clean:
+	rm -f $(EXEC) $(OBJECTS)

--- a/array1.h
+++ b/array1.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <vector>
+#include <cstring>
 
 // In this file:
 //   Array1<T>: a dynamic 1D array for plain-old-data (not objects)
@@ -165,11 +166,11 @@ struct Array1
    Array1<T>& operator=(const Array1<T>& x)
    {
       if(max_n<x.n){
-         T* new_data=(T*)std::malloc(x.n*sizeof(T));
-         if(!new_data) throw std::bad_alloc();
-         std::free(data);
-         data=new_data;
-         max_n=x.n;
+	 T* new_data=(T*)std::malloc(x.n*sizeof(T));
+	 if(!new_data) throw std::bad_alloc();
+	 std::free(data);
+	 data=new_data;
+	 max_n=x.n;
       }
       n=x.n;
       std::memcpy(data, x.data, n*sizeof(T));
@@ -182,7 +183,7 @@ struct Array1
       for(unsigned long i=0; i<n; ++i) if(!(data[i]==x.data[i])) return false;
       return true;
    }
- 
+
    bool operator!=(const Array1<T>& x) const
    {
       if(n!=x.n) return true;
@@ -193,8 +194,8 @@ struct Array1
    bool operator<(const Array1<T>& x) const
    {
       for(unsigned long i=0; i<n && i<x.n; ++i){
-         if(data[i]<x[i]) return true;
-         else if(x[i]<data[i]) return false;
+	 if(data[i]<x[i]) return true;
+	 else if(x[i]<data[i]) return false;
       }
       return n<x.n;
    }
@@ -202,8 +203,8 @@ struct Array1
    bool operator>(const Array1<T>& x) const
    {
       for(unsigned long i=0; i<n && i<x.n; ++i){
-         if(data[i]>x[i]) return true;
-         else if(x[i]>data[i]) return false;
+	 if(data[i]>x[i]) return true;
+	 else if(x[i]>data[i]) return false;
       }
       return n>x.n;
    }
@@ -211,8 +212,8 @@ struct Array1
    bool operator<=(const Array1<T>& x) const
    {
       for(unsigned long i=0; i<n && i<x.n; ++i){
-         if(data[i]<x[i]) return true;
-         else if(x[i]<data[i]) return false;
+	 if(data[i]<x[i]) return true;
+	 else if(x[i]<data[i]) return false;
       }
       return n<=x.n;
    }
@@ -220,8 +221,8 @@ struct Array1
    bool operator>=(const Array1<T>& x) const
    {
       for(unsigned long i=0; i<n && i<x.n; ++i){
-         if(data[i]>x[i]) return true;
-         else if(x[i]>data[i]) return false;
+	 if(data[i]>x[i]) return true;
+	 else if(x[i]>data[i]) return false;
       }
       return n>=x.n;
    }
@@ -237,7 +238,7 @@ struct Array1
    { for(unsigned long i=0; i<n; ++i) data[i]=value; }
 
    void assign(unsigned long num, const T& value)
-   { fill(num, value); } 
+   { fill(num, value); }
 
    // note: copydata may not alias this array's data, and this should not be
    // used when T is a full object (which defines its own copying operation)
@@ -245,11 +246,11 @@ struct Array1
    {
       assert(num==0 || copydata);
       if(num>max_n){
-         if(num>ULONG_MAX/sizeof(T)) throw std::bad_alloc();
-         std::free(data);
-         data=(T*)std::malloc(num*sizeof(T));
-         if(!data) throw std::bad_alloc();
-         max_n=num;
+	 if(num>ULONG_MAX/sizeof(T)) throw std::bad_alloc();
+	 std::free(data);
+	 data=(T*)std::malloc(num*sizeof(T));
+	 if(!data) throw std::bad_alloc();
+	 max_n=num;
       }
       n=num;
       std::memcpy(data, copydata, n*sizeof(T));
@@ -269,8 +270,8 @@ struct Array1
       unsigned long i=0;
       InputIterator p=first;
       for(; p!=last; ++p, ++i){
-         if(i==max_n) grow();
-         data[i]=*p;
+	 if(i==max_n) grow();
+	 data[i]=*p;
       }
       n=i;
    }
@@ -288,7 +289,7 @@ struct Array1
    }
 
    const T& back(void) const
-   { 
+   {
       assert(data && n>0);
       return data[n-1];
    }
@@ -329,18 +330,18 @@ struct Array1
    {
       assert(index<n);
       for(unsigned long i=index; i<n-1; ++i)
-         data[i]=data[i-1];
+	 data[i]=data[i-1];
       pop_back();
    }
 
    void fill(unsigned long num, const T& value)
    {
       if(num>max_n){
-         if(num>ULONG_MAX/sizeof(T)) throw std::bad_alloc();
-         std::free(data);
-         data=(T*)std::malloc(num*sizeof(T));
-         if(!data) throw std::bad_alloc();
-         max_n=num;
+	 if(num>ULONG_MAX/sizeof(T)) throw std::bad_alloc();
+	 std::free(data);
+	 data=(T*)std::malloc(num*sizeof(T));
+	 if(!data) throw std::bad_alloc();
+	 max_n=num;
       }
       n=num;
       for(unsigned long i=0; i<n; ++i) data[i]=value;
@@ -372,7 +373,7 @@ struct Array1
       assert(index<=n);
       push_back(back());
       for(unsigned long i=n-1; i>index; --i)
-         data[i]=data[i-1];
+	 data[i]=data[i-1];
       data[index]=entry;
    }
 
@@ -551,7 +552,7 @@ struct WrapArray1
       for(unsigned long i=0; i<n; ++i) if(!(data[i]==x.data[i])) return false;
       return true;
    }
- 
+
    bool operator!=(const WrapArray1<T>& x) const
    {
       if(n!=x.n) return true;
@@ -562,8 +563,8 @@ struct WrapArray1
    bool operator<(const WrapArray1<T>& x) const
    {
       for(unsigned long i=0; i<n && i<x.n; ++i){
-         if(data[i]<x[i]) return true;
-         else if(x[i]<data[i]) return false;
+	 if(data[i]<x[i]) return true;
+	 else if(x[i]<data[i]) return false;
       }
       return n<x.n;
    }
@@ -571,8 +572,8 @@ struct WrapArray1
    bool operator>(const WrapArray1<T>& x) const
    {
       for(unsigned long i=0; i<n && i<x.n; ++i){
-         if(data[i]>x[i]) return true;
-         else if(x[i]>data[i]) return false;
+	 if(data[i]>x[i]) return true;
+	 else if(x[i]>data[i]) return false;
       }
       return n>x.n;
    }
@@ -580,8 +581,8 @@ struct WrapArray1
    bool operator<=(const WrapArray1<T>& x) const
    {
       for(unsigned long i=0; i<n && i<x.n; ++i){
-         if(data[i]<x[i]) return true;
-         else if(x[i]<data[i]) return false;
+	 if(data[i]<x[i]) return true;
+	 else if(x[i]<data[i]) return false;
       }
       return n<=x.n;
    }
@@ -589,8 +590,8 @@ struct WrapArray1
    bool operator>=(const WrapArray1<T>& x) const
    {
       for(unsigned long i=0; i<n && i<x.n; ++i){
-         if(data[i]>x[i]) return true;
-         else if(x[i]>data[i]) return false;
+	 if(data[i]>x[i]) return true;
+	 else if(x[i]>data[i]) return false;
       }
       return n>=x.n;
    }
@@ -606,7 +607,7 @@ struct WrapArray1
    { for(unsigned long i=0; i<n; ++i) data[i]=value; }
 
    void assign(unsigned long num, const T& value)
-   { fill(num, value); } 
+   { fill(num, value); }
 
    // note: copydata may not alias this array's data, and this should not be
    // used when T is a full object (which defines its own copying operation)
@@ -632,8 +633,8 @@ struct WrapArray1
       unsigned long i=0;
       InputIterator p=first;
       for(; p!=last; ++p, ++i){
-         assert(i<max_n);
-         data[i]=*p;
+	 assert(i<max_n);
+	 data[i]=*p;
       }
       n=i;
    }
@@ -651,7 +652,7 @@ struct WrapArray1
    }
 
    const T& back(void) const
-   { 
+   {
       assert(data && n>0);
       return data[n-1];
    }
@@ -687,7 +688,7 @@ struct WrapArray1
    {
       assert(index<n);
       for(unsigned long i=index; i<n-1; ++i)
-         data[i]=data[i-1];
+	 data[i]=data[i-1];
       pop_back();
    }
 
@@ -715,7 +716,7 @@ struct WrapArray1
       assert(index<=n);
       push_back(back());
       for(unsigned long i=n-1; i>index; --i)
-         data[i]=data[i-1];
+	 data[i]=data[i-1];
       data[index]=entry;
    }
 

--- a/box2dgeometry.cpp
+++ b/box2dgeometry.cpp
@@ -1,6 +1,7 @@
 #include "box2dgeometry.h"
 #include <vector>
 #include "util.h"
+#include <cstdio>
 
 //check if a point in the object's frame of reference is inside or not
 bool Box2DGeometry::is_inside(const Vec2f& point) {
@@ -42,7 +43,7 @@ float Box2DGeometry::get_signed_distance(const Vec2f& point) {
 
 void Box2DGeometry::project_out(Vec2f& point) {
    //Project point to the closest boundary
-   
+
    if(is_inside(point)) {
       const float leftDist = point[0] + width/2;
       const float rightDist = width/2 - point[0];
@@ -50,15 +51,15 @@ void Box2DGeometry::project_out(Vec2f& point) {
       const float topDist = height/2 - point[1];
 
       if ((bottomDist<=rightDist) && (bottomDist<=leftDist) && (bottomDist<=topDist))
-         point[1] = -height/2;
+	 point[1] = -height/2;
       else if ((rightDist<=leftDist) && (rightDist<=bottomDist) && (rightDist<=topDist))
-         point[0] = width/2;
+	 point[0] = width/2;
       else if ((leftDist<=rightDist) && (leftDist<=bottomDist) && (leftDist<=topDist))
-         point[0] = -width/2;
+	 point[0] = -width/2;
       else if ((topDist<=leftDist) && (topDist<=bottomDist) && (topDist<=rightDist))
-         point[1] = height/2;
+	 point[1] = height/2;
    }
-   
+
 }
 
 void Box2DGeometry::get_sample_points(std::vector<Vec2f>& verts) {
@@ -73,10 +74,10 @@ void Box2DGeometry::get_sample_points(std::vector<Vec2f>& verts) {
       verts.push_back( point2 );
 
       if(i != 0 && i != divisions) {
-         Vec2f point3(-width/2,-height/2 + i*dh);
-         Vec2f point4(width/2,-height/2 + i*dh);
-         verts.push_back( point3 );
-         verts.push_back( point4 );
+	 Vec2f point3(-width/2,-height/2 + i*dh);
+	 Vec2f point4(width/2,-height/2 + i*dh);
+	 verts.push_back( point3 );
+	 verts.push_back( point4 );
       }
    }
 }

--- a/fluidsim.cpp
+++ b/fluidsim.cpp
@@ -68,9 +68,9 @@ void FluidSim::set_boundary(float(*phi)(const Vec2f&)) {
 float FluidSim::cfl() {
    float maxvel = 0;
    for (unsigned int i = 0; i < u.a.size(); ++i)
-      maxvel = max(maxvel, fabs(u.a[i]));
+       maxvel = max((double)maxvel, fabs(u.a[i]));
    for (unsigned int i = 0; i < v.a.size(); ++i)
-      maxvel = max(maxvel, fabs(v.a[i]));
+       maxvel = max((double)maxvel, fabs(v.a[i]));
    return dx / maxvel;
 }
 
@@ -81,7 +81,7 @@ void FluidSim::advance(float dt) {
    while (t < dt) {
       float substep = cfl();
       if (t + substep > dt)
-         substep = dt - t;
+	 substep = dt - t;
 
       //Passively advect particles
       advect_particles(substep);
@@ -108,12 +108,12 @@ void FluidSim::advance(float dt) {
       apply_projection(substep);
 
       //Pressure projection only produces valid velocities in faces with non-zero associated face area.
-      //Because the advection step may interpolate from these invalid faces, 
+      //Because the advection step may interpolate from these invalid faces,
       //we must extrapolate velocities from the fluid domain into these zero-area faces.
       extrapolate(u, u_valid);
       extrapolate(v, v_valid);
 
-      //get grid-based approximate solid velocities for use in 
+      //get grid-based approximate solid velocities for use in
       //constrained extrapolation
       recompute_solid_velocity();
 
@@ -145,58 +145,58 @@ void FluidSim::constrain_velocity() {
    //constrain u
    for (int j = 0; j < u.nj; ++j) for (int i = 0; i < u.ni; ++i) {
       if (u_weights(i, j) == 0) {
-         //apply constraint
-         Vec2f pos(i*dx, (j + 0.5f)*dx);
-         Vec2f vel = get_velocity(pos);
-         Vec2f solid_vel = get_solid_velocity(pos);
+	 //apply constraint
+	 Vec2f pos(i*dx, (j + 0.5f)*dx);
+	 Vec2f vel = get_velocity(pos);
+	 Vec2f solid_vel = get_solid_velocity(pos);
 
-         Vec2f solid_normal(0, 0);
-         double solid_phi_val = interpolate_gradient(solid_normal, pos / dx, nodal_solid_phi);
-         normalize(solid_normal);
+	 Vec2f solid_normal(0, 0);
+	 double solid_phi_val = interpolate_gradient(solid_normal, pos / dx, nodal_solid_phi);
+	 normalize(solid_normal);
 
-         Vec2f rigid_normal(0, 0);
-         double rigid_phi_val = interpolate_gradient(rigid_normal, pos / dx, nodal_rigid_phi);
-         normalize(rigid_normal);
+	 Vec2f rigid_normal(0, 0);
+	 double rigid_phi_val = interpolate_gradient(rigid_normal, pos / dx, nodal_rigid_phi);
+	 normalize(rigid_normal);
 
-         if (solid_phi_val < rigid_phi_val) {
-            vel -= dot(vel, solid_normal) * solid_normal;
-            vel += dot(solid_vel, solid_normal) * solid_normal;
-            temp_u(i, j) = vel[0];
-         }
-         else {
-            vel -= dot(vel, rigid_normal) * rigid_normal;
-            vel += dot(solid_vel, rigid_normal) * rigid_normal;
-            temp_u(i, j) = vel[0];
-         }
+	 if (solid_phi_val < rigid_phi_val) {
+	    vel -= dot(vel, solid_normal) * solid_normal;
+	    vel += dot(solid_vel, solid_normal) * solid_normal;
+	    temp_u(i, j) = vel[0];
+	 }
+	 else {
+	    vel -= dot(vel, rigid_normal) * rigid_normal;
+	    vel += dot(solid_vel, rigid_normal) * rigid_normal;
+	    temp_u(i, j) = vel[0];
+	 }
       }
    }
 
    //constrain v
    for (int j = 0; j < v.nj; ++j) for (int i = 0; i < v.ni; ++i) {
       if (v_weights(i, j) == 0) {
-         //apply constraint
-         Vec2f pos((i + 0.5f)*dx, j*dx);
-         Vec2f vel = get_velocity(pos);
-         Vec2f solid_vel(interpolate_value(pos / dx, solid_u), interpolate_value(pos / dx, solid_v));
+	 //apply constraint
+	 Vec2f pos((i + 0.5f)*dx, j*dx);
+	 Vec2f vel = get_velocity(pos);
+	 Vec2f solid_vel(interpolate_value(pos / dx, solid_u), interpolate_value(pos / dx, solid_v));
 
-         Vec2f solid_normal(0, 0);
-         float solid_phi_val = interpolate_gradient(solid_normal, pos / dx, nodal_solid_phi);
-         normalize(solid_normal);
+	 Vec2f solid_normal(0, 0);
+	 float solid_phi_val = interpolate_gradient(solid_normal, pos / dx, nodal_solid_phi);
+	 normalize(solid_normal);
 
-         Vec2f rigid_normal(0, 0);
-         float rigid_phi_val = interpolate_gradient(rigid_normal, pos / dx, nodal_rigid_phi);
-         normalize(rigid_normal);
+	 Vec2f rigid_normal(0, 0);
+	 float rigid_phi_val = interpolate_gradient(rigid_normal, pos / dx, nodal_rigid_phi);
+	 normalize(rigid_normal);
 
-         if (solid_phi_val < rigid_phi_val) {
-            vel -= dot(vel, solid_normal) * solid_normal;
-            vel += dot(solid_vel, solid_normal) * solid_normal;
-            temp_v(i, j) = vel[1];
-         }
-         else {
-            vel -= dot(vel, rigid_normal) * rigid_normal;
-            vel += dot(solid_vel, rigid_normal) * rigid_normal;
-            temp_v(i, j) = vel[1];
-         }
+	 if (solid_phi_val < rigid_phi_val) {
+	    vel -= dot(vel, solid_normal) * solid_normal;
+	    vel += dot(solid_vel, solid_normal) * solid_normal;
+	    temp_v(i, j) = vel[1];
+	 }
+	 else {
+	    vel -= dot(vel, rigid_normal) * rigid_normal;
+	    vel += dot(solid_vel, rigid_normal) * rigid_normal;
+	    temp_v(i, j) = vel[1];
+	 }
       }
    }
 
@@ -215,7 +215,7 @@ void FluidSim::process_collisions() {
    //Should really probably find first collision point and back up to that point,
    //rather than trying to project out of walls.
 
-   //Handle velocities of collision first, 
+   //Handle velocities of collision first,
    //then process positions afterwards
 
    //detect all penetrating, non-separating points
@@ -234,15 +234,15 @@ void FluidSim::process_collisions() {
       Vec2f vertex(vertices[i][0], vertices[i][1]);
       phi = interpolate_normal(normal, vertex, nodal_solid_phi, Vec2f(0, 0), dx);
       if (phi < 0) {
-         Vec2f pt_vel = rbd->getPointVelocity(vertex);
-         if (dot(pt_vel, normal) < 1e-2) {
-            penetrating_points.push_back(i);
-         }
-         if (phi < min_phi) {
-            min_phi = phi;
-            min_ind = i;
-            min_normal = normal;
-         }
+	 Vec2f pt_vel = rbd->getPointVelocity(vertex);
+	 if (dot(pt_vel, normal) < 1e-2) {
+	    penetrating_points.push_back(i);
+	 }
+	 if (phi < min_phi) {
+	    min_phi = phi;
+	    min_ind = i;
+	    min_normal = normal;
+	 }
       }
    }
    int iteration = 0;
@@ -301,20 +301,20 @@ void FluidSim::process_collisions() {
       //recompute list of separating points, remove any separating points
       std::vector<int> new_nonseparating;
       for (unsigned int i = 0; i < penetrating_points.size(); ++i) {
-         float phi;
-         Vec2f normal;
-         int index = penetrating_points[i];
-         Vec2f vertex(vertices[index][0], vertices[index][1]);
-         phi = interpolate_normal(normal, vertex, nodal_solid_phi, 0.5f*dx*Vec2f(1, 1), dx);
+	 float phi;
+	 Vec2f normal;
+	 int index = penetrating_points[i];
+	 Vec2f vertex(vertices[index][0], vertices[index][1]);
+	 phi = interpolate_normal(normal, vertex, nodal_solid_phi, 0.5f*dx*Vec2f(1, 1), dx);
 
-         Vec2f pt_vel = rbd->getPointVelocity(vertex);
-         if (dot(pt_vel, normal) < 1e-2) {
-            new_nonseparating.push_back(index);
-         }
+	 Vec2f pt_vel = rbd->getPointVelocity(vertex);
+	 if (dot(pt_vel, normal) < 1e-2) {
+	    new_nonseparating.push_back(index);
+	 }
       }
       penetrating_points.clear();
       for (unsigned int i = 0; i < new_nonseparating.size(); ++i) {
-         penetrating_points.push_back(new_nonseparating[i]);
+	 penetrating_points.push_back(new_nonseparating[i]);
       }
 
 
@@ -333,22 +333,22 @@ void FluidSim::process_collisions() {
       min_normal = Vec2f(0, 0);
       for (unsigned int i = 0; i < vertices.size(); ++i) {
 
-         float phi;
-         Vec2f normal;
-         Vec2f vertex(vertices[i][0], vertices[i][1]);
-         phi = interpolate_normal(normal, vertex, nodal_solid_phi, Vec2f(0, 0), dx);
+	 float phi;
+	 Vec2f normal;
+	 Vec2f vertex(vertices[i][0], vertices[i][1]);
+	 phi = interpolate_normal(normal, vertex, nodal_solid_phi, Vec2f(0, 0), dx);
 
-         if (phi < min_phi) {
-            min_phi = phi;
-            min_normal = normal;
-         }
+	 if (phi < min_phi) {
+	    min_phi = phi;
+	    min_normal = normal;
+	 }
       }
 
       if (min_phi < 1e-3) {
-         found_penetrating = true;
-         Vec2f com0;
-         rbd->getCOM(com0);
-         rbd->setCOM(com0 - (min_phi - 1e-2f)*min_normal);
+	 found_penetrating = true;
+	 Vec2f com0;
+	 rbd->getCOM(com0);
+	 rbd->setCOM(com0 - (min_phi - 1e-2f)*min_normal);
       }
    } while (found_penetrating);
 
@@ -361,8 +361,8 @@ void FluidSim::update_rigid_body_grids()
    //update level set from current position
    for (int j = 0; j < nj + 1; ++j) {
       for (int i = 0; i < ni + 1; ++i) {
-         Vec2f location(i*dx, j*dx);
-         nodal_rigid_phi(i, j) = rbd->getSignedDist(location);
+	 Vec2f location(i*dx, j*dx);
+	 nodal_rigid_phi(i, j) = rbd->getSignedDist(location);
       }
    }
 
@@ -371,17 +371,17 @@ void FluidSim::update_rigid_body_grids()
    rigid_v_weights.set_zero();
    for (int i = 0; i < rigid_u_weights.ni; ++i) {
       for (int j = 0; j < rigid_u_weights.nj; ++j) {
-         float rigid_bottom = nodal_rigid_phi(i, j);
-         float rigid_top = nodal_rigid_phi(i, j + 1);
-         rigid_u_weights(i, j) = fraction_inside(rigid_bottom, rigid_top);
+	 float rigid_bottom = nodal_rigid_phi(i, j);
+	 float rigid_top = nodal_rigid_phi(i, j + 1);
+	 rigid_u_weights(i, j) = fraction_inside(rigid_bottom, rigid_top);
       }
    }
 
    for (int i = 0; i < v_vol.ni; ++i) {
       for (int j = 1; j < v_vol.nj - 1; ++j) {
-         float rigid_left = nodal_rigid_phi(i, j);
-         float rigid_right = nodal_rigid_phi(i + 1, j);
-         rigid_v_weights(i, j) = fraction_inside(rigid_left, rigid_right);
+	 float rigid_left = nodal_rigid_phi(i, j);
+	 float rigid_right = nodal_rigid_phi(i + 1, j);
+	 rigid_v_weights(i, j) = fraction_inside(rigid_left, rigid_right);
       }
    }
 
@@ -397,22 +397,22 @@ void FluidSim::recompute_solid_velocity()
 {
    for (int i = 0; i < ni + 1; ++i) {
       for (int j = 0; j < nj - 1; ++j) {
-         Vec2f pos(i*dx, (j + 0.5f)*dx);
-         if (0.5f*(nodal_solid_phi(i, j) + nodal_solid_phi(i, j + 1)) < 0.5f*(nodal_rigid_phi(i, j) + nodal_rigid_phi(i, j + 1)))
-            solid_u(i, j) = 0;
-         else {
-            solid_u(i, j) = rbd->getPointVelocity(pos)[0];
-         }
+	 Vec2f pos(i*dx, (j + 0.5f)*dx);
+	 if (0.5f*(nodal_solid_phi(i, j) + nodal_solid_phi(i, j + 1)) < 0.5f*(nodal_rigid_phi(i, j) + nodal_rigid_phi(i, j + 1)))
+	    solid_u(i, j) = 0;
+	 else {
+	    solid_u(i, j) = rbd->getPointVelocity(pos)[0];
+	 }
       }
    }
    for (int i = 0; i < ni - 1; ++i) {
       for (int j = 0; j < nj + 1; ++j) {
-         Vec2f pos((i + 0.5f)*dx, j*dx);
-         if (0.5f*(nodal_solid_phi(i, j) + nodal_solid_phi(i + 1, j)) < 0.5f*(nodal_rigid_phi(i, j) + nodal_rigid_phi(i + 1, j)))
-            solid_v(i, j) = 0;
-         else {
-            solid_v(i, j) = rbd->getPointVelocity(pos)[1];
-         }
+	 Vec2f pos((i + 0.5f)*dx, j*dx);
+	 if (0.5f*(nodal_solid_phi(i, j) + nodal_solid_phi(i + 1, j)) < 0.5f*(nodal_rigid_phi(i, j) + nodal_rigid_phi(i + 1, j)))
+	    solid_v(i, j) = 0;
+	 else {
+	    solid_v(i, j) = rbd->getPointVelocity(pos)[1];
+	 }
       }
    }
 
@@ -456,34 +456,34 @@ void FluidSim::advect_particles(float dt) {
       particles[p] += dt*mid_velocity;
       Vec2f after = particles[p];
 
-      //Particles can still occasionally leave the domain due to truncation errors, 
+      //Particles can still occasionally leave the domain due to truncation errors,
       //interpolation error, or large timesteps, so we project them back in for good measure.
 
       //Try commenting this section out to see the degree of accumulated error.
       float phi_value = interpolate_value(particles[p] / dx, nodal_solid_phi);
       if (phi_value < 0) {
-         Vec2f normal;
-         interpolate_gradient(normal, particles[p] / dx, nodal_solid_phi);
-         normalize(normal);
-         particles[p] -= phi_value*normal;
+	 Vec2f normal;
+	 interpolate_gradient(normal, particles[p] / dx, nodal_solid_phi);
+	 normalize(normal);
+	 particles[p] -= phi_value*normal;
       }
 
       rbd->testCollisionAndProject(particles[p], particles[p]);
    }
 
-   //Simple particle adjustment for when they drift too close. 
+   //Simple particle adjustment for when they drift too close.
    //Scales badly for now.
    for (unsigned int p = 0; p < particles.size(); ++p) {
       for (unsigned int p2 = 0; p2 < particles.size(); ++p2) {
-         if (p == p2) continue;
-         float target_dist = 0.5f*dx;
-         if (dist(particles[p], particles[p2]) < target_dist) {
-            Vec2f sepvec = particles[p] - particles[p2];
-            float curdist = mag(sepvec);
-            normalize(sepvec);
-            particles[p] -= 0.5f*(curdist - target_dist)*sepvec;
-            particles[p2] += 0.5f*(curdist - target_dist)*sepvec;
-         }
+	 if (p == p2) continue;
+	 float target_dist = 0.5f*dx;
+	 if (dist(particles[p], particles[p2]) < target_dist) {
+	    Vec2f sepvec = particles[p] - particles[p2];
+	    float curdist = mag(sepvec);
+	    normalize(sepvec);
+	    particles[p] -= 0.5f*(curdist - target_dist)*sepvec;
+	    particles[p2] += 0.5f*(curdist - target_dist)*sepvec;
+	 }
       }
    }
 
@@ -504,23 +504,23 @@ void FluidSim::compute_phi() {
 
       //compute distance to surrounding few points, keep if it's the minimum
       for (int j_off = j - 2; j_off <= j + 2; ++j_off) for (int i_off = i - 2; i_off <= i + 2; ++i_off) {
-         if (i_off < 0 || i_off >= ni || j_off < 0 || j_off >= nj)
-            continue;
+	 if (i_off < 0 || i_off >= ni || j_off < 0 || j_off >= nj)
+	    continue;
 
-         Vec2f pos((i_off + 0.5f)*dx, (j_off + 0.5f)*dx);
-         float phi_temp = dist(pos, point) - 1.02f*particle_radius;
-         liquid_phi(i_off, j_off) = min(liquid_phi(i_off, j_off), phi_temp);
+	 Vec2f pos((i_off + 0.5f)*dx, (j_off + 0.5f)*dx);
+	 float phi_temp = dist(pos, point) - 1.02f*particle_radius;
+	 liquid_phi(i_off, j_off) = min(liquid_phi(i_off, j_off), phi_temp);
       }
    }
 
    //"extrapolate" phi into solids if nearby
    for (int j = 0; j < nj; ++j) {
       for (int i = 0; i < ni; ++i) {
-         if (liquid_phi(i, j) < 0.5*dx) {
-            float solid_phi_val = 0.25f*(nodal_solid_phi(i, j) + nodal_solid_phi(i + 1, j) + nodal_solid_phi(i, j + 1) + nodal_solid_phi(i + 1, j + 1));
-            if (solid_phi_val < 0)
-               liquid_phi(i, j) = -0.5f*dx;
-         }
+	 if (liquid_phi(i, j) < 0.5*dx) {
+	    float solid_phi_val = 0.25f*(nodal_solid_phi(i, j) + nodal_solid_phi(i + 1, j) + nodal_solid_phi(i, j + 1) + nodal_solid_phi(i + 1, j + 1));
+	    if (solid_phi_val < 0)
+	       liquid_phi(i, j) = -0.5f*dx;
+	 }
       }
    }
 
@@ -605,20 +605,20 @@ void compute_volume_fractions(const Array2f& levelset, Array2f& fractions, Vec2f
    int sample_max = subdivision*subdivision;
    for (int j = 0; j < fractions.nj; ++j) {
       for (int i = 0; i < fractions.ni; ++i) {
-         float start_x = fraction_origin[0] + (float)i;
-         float start_y = fraction_origin[1] + (float)j;
-         int incount = 0;
+	 float start_x = fraction_origin[0] + (float)i;
+	 float start_y = fraction_origin[1] + (float)j;
+	 int incount = 0;
 
-         for (int sub_j = 0; sub_j < subdivision; ++sub_j) {
-            for (int sub_i = 0; sub_i < subdivision; ++sub_i) {
-               float x_pos = start_x + (sub_i + 0.5f)*sub_dx;
-               float y_pos = start_y + (sub_j + 0.5f)*sub_dx;
-               float phi_val = interpolate_value(Vec2f(x_pos, y_pos), levelset);
-               if (phi_val < 0)
-                  ++incount;
-            }
-         }
-         fractions(i, j) = (float)incount / (float)sample_max;
+	 for (int sub_j = 0; sub_j < subdivision; ++sub_j) {
+	    for (int sub_i = 0; sub_i < subdivision; ++sub_i) {
+	       float x_pos = start_x + (sub_i + 0.5f)*sub_dx;
+	       float y_pos = start_y + (sub_j + 0.5f)*sub_dx;
+	       float phi_val = interpolate_value(Vec2f(x_pos, y_pos), levelset);
+	       if (phi_val < 0)
+		  ++incount;
+	    }
+	 }
+	 fractions(i, j) = (float)incount / (float)sample_max;
       }
    }
 
@@ -642,26 +642,26 @@ void FluidSim::solve_pressure(float dt) {
    rbd->getCOM(centre_of_mass);
    for (int j = 0; j != nj; ++j) {
       for (int i = 0; i != ni; ++i) {
-         double u_term = (rigid_u_weights(i + 1, j) - rigid_u_weights(i, j)) / dx;
-         double v_term = (rigid_v_weights(i, j + 1) - rigid_v_weights(i, j)) / dx;
+	 double u_term = (rigid_u_weights(i + 1, j) - rigid_u_weights(i, j)) / dx;
+	 double v_term = (rigid_v_weights(i, j + 1) - rigid_v_weights(i, j)) / dx;
 
-         // Translation coupling
-         base_trans_x(i, j) = u_term;
-         base_trans_y(i, j) = v_term;
+	 // Translation coupling
+	 base_trans_x(i, j) = u_term;
+	 base_trans_y(i, j) = v_term;
 
-         // Rotation coupling
-         Vec2f position((i + 0.5f) * dx, (j + 0.5f) * dx);
-         Vec2f rad = position - centre_of_mass;
-         base_rot_z(i, j) = rad[0] * v_term - rad[1] * u_term;
+	 // Rotation coupling
+	 Vec2f position((i + 0.5f) * dx, (j + 0.5f) * dx);
+	 Vec2f rad = position - centre_of_mass;
+	 base_rot_z(i, j) = rad[0] * v_term - rad[1] * u_term;
       }
    }
 
    int ni = v.ni;
    int nj = u.nj;
    int system_size = ni*nj;
-  
-     
-   std::vector<Eigen::Triplet<double>> triplets;
+
+
+   std::vector< Eigen::Triplet<double> > triplets;
    Eigen::VectorXd Erhs(system_size);
 
    bool any_liquid_surface = false;
@@ -669,79 +669,79 @@ void FluidSim::solve_pressure(float dt) {
    //Build the linear system for pressure
    for (int j = 1; j < nj - 1; ++j) {
       for (int i = 1; i < ni - 1; ++i) {
-         int index = i + ni*j;
-         Erhs[index] = 0;
-         float centre_phi = liquid_phi(i, j);
-         if (centre_phi < 0) {
+	 int index = i + ni*j;
+	 Erhs[index] = 0;
+	 float centre_phi = liquid_phi(i, j);
+	 if (centre_phi < 0) {
 
-            //right neighbour
-            float term = u_weights(i + 1, j) * dt / sqr(dx);
-            if (term > 0) {
-               float right_phi = liquid_phi(i + 1, j);
-               if (right_phi < 0) {
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term));
-                  triplets.push_back(Eigen::Triplet<double>(index, index+1, -term));
-               }
-               else {
-                  float theta = fraction_inside(centre_phi, right_phi);
-                  if (theta < 0.01f) theta = 0.01f;
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term/theta));
-                  any_liquid_surface = true;
-               }
-               Erhs[index] -= u_weights(i + 1, j)*u(i + 1, j) / dx;
-            }
+	    //right neighbour
+	    float term = u_weights(i + 1, j) * dt / sqr(dx);
+	    if (term > 0) {
+	       float right_phi = liquid_phi(i + 1, j);
+	       if (right_phi < 0) {
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term));
+		  triplets.push_back(Eigen::Triplet<double>(index, index+1, -term));
+	       }
+	       else {
+		  float theta = fraction_inside(centre_phi, right_phi);
+		  if (theta < 0.01f) theta = 0.01f;
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term/theta));
+		  any_liquid_surface = true;
+	       }
+	       Erhs[index] -= u_weights(i + 1, j)*u(i + 1, j) / dx;
+	    }
 
-            //left neighbour
-            term = u_weights(i, j) * dt / sqr(dx);
-            if (term > 0) {
-               float left_phi = liquid_phi(i - 1, j);
-               if (left_phi < 0) {
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term));
-                  triplets.push_back(Eigen::Triplet<double>(index, index - 1, -term));
-               }
-               else {
-                  float theta = fraction_inside(centre_phi, left_phi);
-                  if (theta < 0.01f) theta = 0.01f;
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term/theta));
-                  any_liquid_surface = true;
-               }
-               Erhs[index] += u_weights(i, j)*u(i, j) / dx;
-            }
+	    //left neighbour
+	    term = u_weights(i, j) * dt / sqr(dx);
+	    if (term > 0) {
+	       float left_phi = liquid_phi(i - 1, j);
+	       if (left_phi < 0) {
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term));
+		  triplets.push_back(Eigen::Triplet<double>(index, index - 1, -term));
+	       }
+	       else {
+		  float theta = fraction_inside(centre_phi, left_phi);
+		  if (theta < 0.01f) theta = 0.01f;
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term/theta));
+		  any_liquid_surface = true;
+	       }
+	       Erhs[index] += u_weights(i, j)*u(i, j) / dx;
+	    }
 
-            //top neighbour
-            term = v_weights(i, j + 1) * dt / sqr(dx);
-            if (term > 0) {
-               float top_phi = liquid_phi(i, j + 1);
-               if (top_phi < 0) {
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term));
-                  triplets.push_back(Eigen::Triplet<double>(index, index + ni, -term));
-               }
-               else {
-                  float theta = fraction_inside(centre_phi, top_phi);
-                  if (theta < 0.01f) theta = 0.01f;
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term/theta));
-                  any_liquid_surface = true;
-               }
-               Erhs[index] -= v_weights(i, j + 1)*v(i, j + 1) / dx;
-            }
+	    //top neighbour
+	    term = v_weights(i, j + 1) * dt / sqr(dx);
+	    if (term > 0) {
+	       float top_phi = liquid_phi(i, j + 1);
+	       if (top_phi < 0) {
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term));
+		  triplets.push_back(Eigen::Triplet<double>(index, index + ni, -term));
+	       }
+	       else {
+		  float theta = fraction_inside(centre_phi, top_phi);
+		  if (theta < 0.01f) theta = 0.01f;
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term/theta));
+		  any_liquid_surface = true;
+	       }
+	       Erhs[index] -= v_weights(i, j + 1)*v(i, j + 1) / dx;
+	    }
 
-            //bottom neighbour
-            term = v_weights(i, j) * dt / sqr(dx);
-            if (term > 0) {
-               float bot_phi = liquid_phi(i, j - 1);
-               if (bot_phi < 0) {
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term));
-                  triplets.push_back(Eigen::Triplet<double>(index, index -ni, -term));
-               }
-               else {
-                  float theta = fraction_inside(centre_phi, bot_phi);
-                  if (theta < 0.01f) theta = 0.01f;
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term/theta));
-                  any_liquid_surface = true;
-               }
-               Erhs[index] += v_weights(i, j)*v(i, j) / dx;
-            }
-         }
+	    //bottom neighbour
+	    term = v_weights(i, j) * dt / sqr(dx);
+	    if (term > 0) {
+	       float bot_phi = liquid_phi(i, j - 1);
+	       if (bot_phi < 0) {
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term));
+		  triplets.push_back(Eigen::Triplet<double>(index, index -ni, -term));
+	       }
+	       else {
+		  float theta = fraction_inside(centre_phi, bot_phi);
+		  if (theta < 0.01f) theta = 0.01f;
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term/theta));
+		  any_liquid_surface = true;
+	       }
+	       Erhs[index] += v_weights(i, j)*v(i, j) / dx;
+	    }
+	 }
       }
    }
 
@@ -756,60 +756,60 @@ void FluidSim::solve_pressure(float dt) {
 
    for (int j = 0; j < nj; ++j) {
       for (int i = 0; i < ni; ++i) {
-         int index = i + ni*j;
-         float centre_phi = liquid_phi(i, j);
-         if (centre_phi < 0) {
+	 int index = i + ni*j;
+	 float centre_phi = liquid_phi(i, j);
+	 if (centre_phi < 0) {
 
-            //RHS contributions...
-            // Translation
-            Erhs[index] -= solidLinearVelocity[0] * base_trans_x(i, j);
-            Erhs[index] -= solidLinearVelocity[1] * base_trans_y(i, j);
+	    //RHS contributions...
+	    // Translation
+	    Erhs[index] -= solidLinearVelocity[0] * base_trans_x(i, j);
+	    Erhs[index] -= solidLinearVelocity[1] * base_trans_y(i, j);
 
-            //Rotation
-            Erhs[index] -= angular_velocity * base_rot_z(i, j);
+	    //Rotation
+	    Erhs[index] -= angular_velocity * base_rot_z(i, j);
 
-            //LHS matrix contributions
-            for (int k = 0; k < ni; ++k) {
-               for (int m = 0; m < nj; ++m) {
-                  double val = 0;
-                  float other_phi = liquid_phi(k, m);
-                  if (other_phi < 0) {
-                     //Translation
-                     val += dt * base_trans_x(i, j) * base_trans_x(k, m) / rigid_u_mass;
-                     val += dt * base_trans_y(i, j) * base_trans_y(k, m) / rigid_v_mass;
+	    //LHS matrix contributions
+	    for (int k = 0; k < ni; ++k) {
+	       for (int m = 0; m < nj; ++m) {
+		  double val = 0;
+		  float other_phi = liquid_phi(k, m);
+		  if (other_phi < 0) {
+		     //Translation
+		     val += dt * base_trans_x(i, j) * base_trans_x(k, m) / rigid_u_mass;
+		     val += dt * base_trans_y(i, j) * base_trans_y(k, m) / rigid_v_mass;
 
-                     //Rotation
-                     val += dt * base_rot_z(i, j) * base_rot_z(k, m) * Jinv;
+		     //Rotation
+		     val += dt * base_rot_z(i, j) * base_rot_z(k, m) * Jinv;
 
-                     if (fabs(val) > 1e-10) {
-                        triplets.push_back(Eigen::Triplet<double>(i + ni*j, k + ni*m, val));
-                     }
-                  }
-               }
-            }
+		     if (fabs(val) > 1e-10) {
+			triplets.push_back(Eigen::Triplet<double>(i + ni*j, k + ni*m, val));
+		     }
+		  }
+	       }
+	    }
 
-         }
+	 }
       }
    }
 
    //Solve the system using one of Eigen's sparse solvers
-   
+
    Eigen::SparseMatrix<double> Ematrix(system_size, system_size);
    Ematrix.setFromTriplets(triplets.begin(), triplets.end());
 
-   
+
    //replace empty rows/cols to make (at least) positive semi-definite
    for (int row = 0; row < Ematrix.outerSize(); ++row) {
-      
+
       //TODO: There has to be a way to extract this count intelligently in Eigen
       //rather than simply counting.
       int count = 0;
       for (Eigen::SparseMatrix<double>::InnerIterator it(Ematrix, row); it; ++it){
-         ++count;
+	 ++count;
       }
       if (count == 0) {
-         Ematrix.coeffRef(row, row) = 1;
-         Erhs[row] = 0;
+	 Ematrix.coeffRef(row, row) = 1;
+	 Erhs[row] = 0;
       }
    }
 
@@ -819,33 +819,33 @@ void FluidSim::solve_pressure(float dt) {
    if (!any_liquid_surface) {
       int del_index = -1;
       for (int j = 0; j < nj && del_index <0; ++j) for (int i = 0; i < ni && del_index <0; ++i) {
-         int index = i + ni*j;
-         float centre_phi = liquid_phi(i, j);
-         if (centre_phi < 0 && (u_weights(i + 1, j) > 0 || u_weights(i, j) > 0 || v_weights(i, j + 1) > 0 || v_weights(i, j) > 0)) {
-            del_index = index;
-            break;
-         }
+	 int index = i + ni*j;
+	 float centre_phi = liquid_phi(i, j);
+	 if (centre_phi < 0 && (u_weights(i + 1, j) > 0 || u_weights(i, j) > 0 || v_weights(i, j + 1) > 0 || v_weights(i, j) > 0)) {
+	    del_index = index;
+	    break;
+	 }
       }
-      
+
       //zero the RHS
       Erhs[del_index] = 0;
 
       //replace row/col with identity
       for (Eigen::SparseMatrix<double>::InnerIterator it(Ematrix, del_index); it; ++it)
       {
-         if (it.col() == it.row()) {
-            Ematrix.coeffRef(it.row(), it.col()) = 1;
-         }
-         else {
-            Ematrix.coeffRef(it.row(), it.col()) = 0;
-            Ematrix.coeffRef(it.col(), it.row()) = 0;
-         }
+	 if (it.col() == it.row()) {
+	    Ematrix.coeffRef(it.row(), it.col()) = 1;
+	 }
+	 else {
+	    Ematrix.coeffRef(it.row(), it.col()) = 0;
+	    Ematrix.coeffRef(it.col(), it.row()) = 0;
+	 }
       }
    }
    Ematrix.makeCompressed();
 
-   
-   Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> Esolver;
+
+   Eigen::SimplicialLDLT< Eigen::SparseMatrix<double> > Esolver;
    Esolver.compute(Ematrix);
    if (Esolver.info() != Eigen::Success) {
       std::cout << "Eigen factorization failed.\n";
@@ -858,37 +858,37 @@ void FluidSim::solve_pressure(float dt) {
       Eigen::saveMarket(Ematrix, "pressurematrix.matrix");
       exit(0);
    }
-   
 
- 
+
+
    //Apply the velocity update
    u_valid.assign(0);
    for (int j = 0; j < u.nj; ++j) for (int i = 1; i < u.ni - 1; ++i) {
       int index = i + j*ni;
       if (u_weights(i, j) > 0 && (liquid_phi(i, j) < 0 || liquid_phi(i - 1, j) < 0)) {
-         float theta = 1;
-         if (liquid_phi(i, j) >= 0 || liquid_phi(i - 1, j) >= 0)
-            theta = fraction_inside(liquid_phi(i - 1, j), liquid_phi(i, j));
-         if (theta < 0.01f) theta = 0.01f;
-         u(i, j) -= dt  * (float)(pressure[index] - pressure[index - 1]) / dx / theta;
-         u_valid(i, j) = 1;
+	 float theta = 1;
+	 if (liquid_phi(i, j) >= 0 || liquid_phi(i - 1, j) >= 0)
+	    theta = fraction_inside(liquid_phi(i - 1, j), liquid_phi(i, j));
+	 if (theta < 0.01f) theta = 0.01f;
+	 u(i, j) -= dt  * (float)(pressure[index] - pressure[index - 1]) / dx / theta;
+	 u_valid(i, j) = 1;
       }
       else
-         u(i, j) = 0;
+	 u(i, j) = 0;
    }
    v_valid.assign(0);
    for (int j = 1; j < v.nj - 1; ++j) for (int i = 0; i < v.ni; ++i) {
       int index = i + j*ni;
       if (v_weights(i, j) > 0 && (liquid_phi(i, j) < 0 || liquid_phi(i, j - 1) < 0)) {
-         float theta = 1;
-         if (liquid_phi(i, j) >= 0 || liquid_phi(i, j - 1) >= 0)
-            theta = fraction_inside(liquid_phi(i, j - 1), liquid_phi(i, j));
-         if (theta < 0.01f) theta = 0.01f;
-         v(i, j) -= dt  * (float)(pressure[index] - pressure[index - ni]) / dx / theta;
-         v_valid(i, j) = 1;
+	 float theta = 1;
+	 if (liquid_phi(i, j) >= 0 || liquid_phi(i, j - 1) >= 0)
+	    theta = fraction_inside(liquid_phi(i, j - 1), liquid_phi(i, j));
+	 if (theta < 0.01f) theta = 0.01f;
+	 v(i, j) -= dt  * (float)(pressure[index] - pressure[index - ni]) / dx / theta;
+	 v_valid(i, j) = 1;
       }
       else
-         v(i, j) = 0;
+	 v(i, j) = 0;
    }
 
    //Get pressure update to apply to solid
@@ -898,14 +898,14 @@ void FluidSim::solve_pressure(float dt) {
    rbd->getAngularMomentum(updated_rigid_angular_momentum);
    for (int j = 0; j < nj; ++j) {
       for (int i = 0; i < ni; ++i) {
-         int index = i + ni*j;
-         float centre_phi = liquid_phi(i, j);
-         if (centre_phi < 0) {
-            updated_rigid_linear_velocity[0] += (float)(dt*base_trans_x(i, j)*pressure[index] / rigid_u_mass);
-            updated_rigid_linear_velocity[1] += (float)(dt*base_trans_y(i, j)*pressure[index] / rigid_v_mass);
+	 int index = i + ni*j;
+	 float centre_phi = liquid_phi(i, j);
+	 if (centre_phi < 0) {
+	    updated_rigid_linear_velocity[0] += (float)(dt*base_trans_x(i, j)*pressure[index] / rigid_u_mass);
+	    updated_rigid_linear_velocity[1] += (float)(dt*base_trans_y(i, j)*pressure[index] / rigid_v_mass);
 
-            updated_rigid_angular_momentum += (float)(dt*base_rot_z(i, j) * pressure[index]);
-         }
+	    updated_rigid_angular_momentum += (float)(dt*base_rot_z(i, j) * pressure[index]);
+	 }
       }
    }
 
@@ -922,17 +922,17 @@ void FluidSim::solve_pressure_indefinite(float dt) {
    rbd->getCOM(centre_of_mass);
    for (int j = 0; j != nj; ++j) {
       for (int i = 0; i != ni; ++i) {
-         double u_term = (rigid_u_weights(i + 1, j) - rigid_u_weights(i, j)) / dx;
-         double v_term = (rigid_v_weights(i, j + 1) - rigid_v_weights(i, j)) / dx;
+	 double u_term = (rigid_u_weights(i + 1, j) - rigid_u_weights(i, j)) / dx;
+	 double v_term = (rigid_v_weights(i, j + 1) - rigid_v_weights(i, j)) / dx;
 
-         // Translation coupling
-         base_trans_x(i, j) = u_term;
-         base_trans_y(i, j) = v_term;
+	 // Translation coupling
+	 base_trans_x(i, j) = u_term;
+	 base_trans_y(i, j) = v_term;
 
-         // Rotation coupling
-         Vec2f position((i + 0.5f) * dx, (j + 0.5f) * dx);
-         Vec2f rad = position - centre_of_mass;
-         base_rot_z(i, j) = rad[0] * v_term - rad[1] * u_term;
+	 // Rotation coupling
+	 Vec2f position((i + 0.5f) * dx, (j + 0.5f) * dx);
+	 Vec2f rad = position - centre_of_mass;
+	 base_rot_z(i, j) = rad[0] * v_term - rad[1] * u_term;
       }
    }
 
@@ -940,7 +940,7 @@ void FluidSim::solve_pressure_indefinite(float dt) {
    int nj = u.nj;
    int system_size = ni*nj + 3; //pressure samples plus 3 entries for rigid solid velocity (translational and rotational)
 
-   std::vector<Eigen::Triplet<double>> triplets;
+   std::vector< Eigen::Triplet<double> > triplets;
    Eigen::VectorXd Erhs(system_size);
 
    bool any_liquid_surface = false;
@@ -948,79 +948,79 @@ void FluidSim::solve_pressure_indefinite(float dt) {
    //Build the linear system for pressure
    for (int j = 1; j < nj - 1; ++j) {
       for (int i = 1; i < ni - 1; ++i) {
-         int index = i + ni*j;
-         Erhs[index] = 0;
-         float centre_phi = liquid_phi(i, j);
-         if (centre_phi < 0) {
+	 int index = i + ni*j;
+	 Erhs[index] = 0;
+	 float centre_phi = liquid_phi(i, j);
+	 if (centre_phi < 0) {
 
-            //right neighbour
-            float term = u_weights(i + 1, j) * dt / sqr(dx);
-            if (term > 0) {
-               float right_phi = liquid_phi(i + 1, j);
-               if (right_phi < 0) {
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term));
-                  triplets.push_back(Eigen::Triplet<double>(index, index + 1, -term));
-               }
-               else {
-                  float theta = fraction_inside(centre_phi, right_phi);
-                  if (theta < 0.01f) theta = 0.01f;
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term / theta));
-                  any_liquid_surface = true;
-               }
-               Erhs[index] -= u_weights(i + 1, j)*u(i + 1, j) / dx;
-            }
+	    //right neighbour
+	    float term = u_weights(i + 1, j) * dt / sqr(dx);
+	    if (term > 0) {
+	       float right_phi = liquid_phi(i + 1, j);
+	       if (right_phi < 0) {
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term));
+		  triplets.push_back(Eigen::Triplet<double>(index, index + 1, -term));
+	       }
+	       else {
+		  float theta = fraction_inside(centre_phi, right_phi);
+		  if (theta < 0.01f) theta = 0.01f;
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term / theta));
+		  any_liquid_surface = true;
+	       }
+	       Erhs[index] -= u_weights(i + 1, j)*u(i + 1, j) / dx;
+	    }
 
-            //left neighbour
-            term = u_weights(i, j) * dt / sqr(dx);
-            if (term > 0) {
-               float left_phi = liquid_phi(i - 1, j);
-               if (left_phi < 0) {
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term));
-                  triplets.push_back(Eigen::Triplet<double>(index, index - 1, -term));
-               }
-               else {
-                  float theta = fraction_inside(centre_phi, left_phi);
-                  if (theta < 0.01f) theta = 0.01f;
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term / theta));
-                  any_liquid_surface = true;
-               }
-               Erhs[index] += u_weights(i, j)*u(i, j) / dx;
-            }
+	    //left neighbour
+	    term = u_weights(i, j) * dt / sqr(dx);
+	    if (term > 0) {
+	       float left_phi = liquid_phi(i - 1, j);
+	       if (left_phi < 0) {
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term));
+		  triplets.push_back(Eigen::Triplet<double>(index, index - 1, -term));
+	       }
+	       else {
+		  float theta = fraction_inside(centre_phi, left_phi);
+		  if (theta < 0.01f) theta = 0.01f;
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term / theta));
+		  any_liquid_surface = true;
+	       }
+	       Erhs[index] += u_weights(i, j)*u(i, j) / dx;
+	    }
 
-            //top neighbour
-            term = v_weights(i, j + 1) * dt / sqr(dx);
-            if (term > 0) {
-               float top_phi = liquid_phi(i, j + 1);
-               if (top_phi < 0) {
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term));
-                  triplets.push_back(Eigen::Triplet<double>(index, index + ni, -term));
-               }
-               else {
-                  float theta = fraction_inside(centre_phi, top_phi);
-                  if (theta < 0.01f) theta = 0.01f;
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term / theta));
-                  any_liquid_surface = true;
-               }
-               Erhs[index] -= v_weights(i, j + 1)*v(i, j + 1) / dx;
-            }
+	    //top neighbour
+	    term = v_weights(i, j + 1) * dt / sqr(dx);
+	    if (term > 0) {
+	       float top_phi = liquid_phi(i, j + 1);
+	       if (top_phi < 0) {
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term));
+		  triplets.push_back(Eigen::Triplet<double>(index, index + ni, -term));
+	       }
+	       else {
+		  float theta = fraction_inside(centre_phi, top_phi);
+		  if (theta < 0.01f) theta = 0.01f;
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term / theta));
+		  any_liquid_surface = true;
+	       }
+	       Erhs[index] -= v_weights(i, j + 1)*v(i, j + 1) / dx;
+	    }
 
-            //bottom neighbour
-            term = v_weights(i, j) * dt / sqr(dx);
-            if (term > 0) {
-               float bot_phi = liquid_phi(i, j - 1);
-               if (bot_phi < 0) {
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term));
-                  triplets.push_back(Eigen::Triplet<double>(index, index - ni, -term));
-               }
-               else {
-                  float theta = fraction_inside(centre_phi, bot_phi);
-                  if (theta < 0.01f) theta = 0.01f;
-                  triplets.push_back(Eigen::Triplet<double>(index, index, term / theta));
-                  any_liquid_surface = true;
-               }
-               Erhs[index] += v_weights(i, j)*v(i, j) / dx;
-            }
-         }
+	    //bottom neighbour
+	    term = v_weights(i, j) * dt / sqr(dx);
+	    if (term > 0) {
+	       float bot_phi = liquid_phi(i, j - 1);
+	       if (bot_phi < 0) {
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term));
+		  triplets.push_back(Eigen::Triplet<double>(index, index - ni, -term));
+	       }
+	       else {
+		  float theta = fraction_inside(centre_phi, bot_phi);
+		  if (theta < 0.01f) theta = 0.01f;
+		  triplets.push_back(Eigen::Triplet<double>(index, index, term / theta));
+		  any_liquid_surface = true;
+	       }
+	       Erhs[index] += v_weights(i, j)*v(i, j) / dx;
+	    }
+	 }
       }
    }
 
@@ -1043,26 +1043,26 @@ void FluidSim::solve_pressure_indefinite(float dt) {
 
    for (int j = 0; j < nj; ++j) {
       for (int i = 0; i < ni; ++i) {
-         int index = i + ni*j;
-         float centre_phi = liquid_phi(i, j);
-         if (centre_phi < 0) {
-            //add J'V to top-right block
-            //and also Jp to bottom-left block
-            
-            double val_x = base_trans_x(i, j);
-            double val_y = base_trans_y(i, j);
-            double val_z = base_rot_z(i, j);
-            if (fabs(val_x) > 1e-10) {
-               triplets.push_back(Eigen::Triplet<double>(i + ni*j, rigidbody_start,     val_x));  //x-trans
-               triplets.push_back(Eigen::Triplet<double>(i + ni*j, rigidbody_start + 1, val_y)); //y-trans
-               triplets.push_back(Eigen::Triplet<double>(i + ni*j, rigidbody_start + 2, val_z)); //z-rot
+	 int index = i + ni*j;
+	 float centre_phi = liquid_phi(i, j);
+	 if (centre_phi < 0) {
+	    //add J'V to top-right block
+	    //and also Jp to bottom-left block
 
-               triplets.push_back(Eigen::Triplet<double>(rigidbody_start,     i + ni*j, val_x));  //x-trans
-               triplets.push_back(Eigen::Triplet<double>(rigidbody_start + 1, i + ni*j, val_y)); //y-trans
-               triplets.push_back(Eigen::Triplet<double>(rigidbody_start + 2, i + ni*j, val_z)); //z-rot
-            }
+	    double val_x = base_trans_x(i, j);
+	    double val_y = base_trans_y(i, j);
+	    double val_z = base_rot_z(i, j);
+	    if (fabs(val_x) > 1e-10) {
+	       triplets.push_back(Eigen::Triplet<double>(i + ni*j, rigidbody_start,     val_x));  //x-trans
+	       triplets.push_back(Eigen::Triplet<double>(i + ni*j, rigidbody_start + 1, val_y)); //y-trans
+	       triplets.push_back(Eigen::Triplet<double>(i + ni*j, rigidbody_start + 2, val_z)); //z-rot
 
-         }
+	       triplets.push_back(Eigen::Triplet<double>(rigidbody_start,     i + ni*j, val_x));  //x-trans
+	       triplets.push_back(Eigen::Triplet<double>(rigidbody_start + 1, i + ni*j, val_y)); //y-trans
+	       triplets.push_back(Eigen::Triplet<double>(rigidbody_start + 2, i + ni*j, val_z)); //z-rot
+	    }
+
+	 }
       }
    }
 
@@ -1070,39 +1070,39 @@ void FluidSim::solve_pressure_indefinite(float dt) {
 
    for (int j = 0; j < nj; ++j) {
       for (int i = 0; i < ni; ++i) {
-         int index = i + ni*j;
-         float centre_phi = liquid_phi(i, j);
-         if (centre_phi < 0) {
+	 int index = i + ni*j;
+	 float centre_phi = liquid_phi(i, j);
+	 if (centre_phi < 0) {
 
-            //RHS contributions...
-            // Translation
-            Erhs[index] -= solidLinearVelocity[0] * base_trans_x(i, j);
-            Erhs[index] -= solidLinearVelocity[1] * base_trans_y(i, j);
+	    //RHS contributions...
+	    // Translation
+	    Erhs[index] -= solidLinearVelocity[0] * base_trans_x(i, j);
+	    Erhs[index] -= solidLinearVelocity[1] * base_trans_y(i, j);
 
-            //Rotation
-            Erhs[index] -= angular_velocity * base_rot_z(i, j);
+	    //Rotation
+	    Erhs[index] -= angular_velocity * base_rot_z(i, j);
 
-            //LHS matrix contributions
-            for (int k = 0; k < ni; ++k) {
-               for (int m = 0; m < nj; ++m) {
-                  double val = 0;
-                  float other_phi = liquid_phi(k, m);
-                  if (other_phi < 0) {
-                     //Translation
-                     val += dt * base_trans_x(i, j) * base_trans_x(k, m) / rigid_u_mass;
-                     val += dt * base_trans_y(i, j) * base_trans_y(k, m) / rigid_v_mass;
+	    //LHS matrix contributions
+	    for (int k = 0; k < ni; ++k) {
+	       for (int m = 0; m < nj; ++m) {
+		  double val = 0;
+		  float other_phi = liquid_phi(k, m);
+		  if (other_phi < 0) {
+		     //Translation
+		     val += dt * base_trans_x(i, j) * base_trans_x(k, m) / rigid_u_mass;
+		     val += dt * base_trans_y(i, j) * base_trans_y(k, m) / rigid_v_mass;
 
-                     //Rotation
-                     val += dt * base_rot_z(i, j) * base_rot_z(k, m) * Jinv;
+		     //Rotation
+		     val += dt * base_rot_z(i, j) * base_rot_z(k, m) * Jinv;
 
-                     if (fabs(val) > 1e-10) {
-                        triplets.push_back(Eigen::Triplet<double>(i + ni*j, k + ni*m, val));
-                     }
-                  }
-               }
-            }
+		     if (fabs(val) > 1e-10) {
+			triplets.push_back(Eigen::Triplet<double>(i + ni*j, k + ni*m, val));
+		     }
+		  }
+	       }
+	    }
 
-         }
+	 }
       }
    }
    */
@@ -1119,11 +1119,11 @@ void FluidSim::solve_pressure_indefinite(float dt) {
       //rather than simply counting.
       int count = 0;
       for (Eigen::SparseMatrix<double>::InnerIterator it(Ematrix, row); it; ++it){
-         ++count;
+	 ++count;
       }
       if (count == 0) {
-         Ematrix.coeffRef(row, row) = 1;
-         Erhs[row] = 0;
+	 Ematrix.coeffRef(row, row) = 1;
+	 Erhs[row] = 0;
       }
    }
 
@@ -1133,12 +1133,12 @@ void FluidSim::solve_pressure_indefinite(float dt) {
    if (!any_liquid_surface) {
       int del_index = -1;
       for (int j = 0; j < nj && del_index <0; ++j) for (int i = 0; i < ni && del_index <0; ++i) {
-         int index = i + ni*j;
-         float centre_phi = liquid_phi(i, j);
-         if (centre_phi < 0 && (u_weights(i + 1, j) > 0 || u_weights(i, j) > 0 || v_weights(i, j + 1) > 0 || v_weights(i, j) > 0)) {
-            del_index = index;
-            break;
-         }
+	 int index = i + ni*j;
+	 float centre_phi = liquid_phi(i, j);
+	 if (centre_phi < 0 && (u_weights(i + 1, j) > 0 || u_weights(i, j) > 0 || v_weights(i, j + 1) > 0 || v_weights(i, j) > 0)) {
+	    del_index = index;
+	    break;
+	 }
       }
 
       //zero the RHS
@@ -1147,19 +1147,19 @@ void FluidSim::solve_pressure_indefinite(float dt) {
       //replace row/col with identity
       for (Eigen::SparseMatrix<double>::InnerIterator it(Ematrix, del_index); it; ++it)
       {
-         if (it.col() == it.row()) {
-            Ematrix.coeffRef(it.row(), it.col()) = 1;
-         }
-         else {
-            Ematrix.coeffRef(it.row(), it.col()) = 0;
-            Ematrix.coeffRef(it.col(), it.row()) = 0;
-         }
+	 if (it.col() == it.row()) {
+	    Ematrix.coeffRef(it.row(), it.col()) = 1;
+	 }
+	 else {
+	    Ematrix.coeffRef(it.row(), it.col()) = 0;
+	    Ematrix.coeffRef(it.col(), it.row()) = 0;
+	 }
       }
    }
    Ematrix.makeCompressed();
 
 
-   Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> Esolver;
+   Eigen::SimplicialLDLT< Eigen::SparseMatrix<double> > Esolver;
    Esolver.compute(Ematrix);
    if (Esolver.info() != Eigen::Success) {
       std::cout << "Eigen factorization failed.\n";
@@ -1180,29 +1180,29 @@ void FluidSim::solve_pressure_indefinite(float dt) {
    for (int j = 0; j < u.nj; ++j) for (int i = 1; i < u.ni - 1; ++i) {
       int index = i + j*ni;
       if (u_weights(i, j) > 0 && (liquid_phi(i, j) < 0 || liquid_phi(i - 1, j) < 0)) {
-         float theta = 1;
-         if (liquid_phi(i, j) >= 0 || liquid_phi(i - 1, j) >= 0)
-            theta = fraction_inside(liquid_phi(i - 1, j), liquid_phi(i, j));
-         if (theta < 0.01f) theta = 0.01f;
-         u(i, j) -= dt  * (float)(pressure[index] - pressure[index - 1]) / dx / theta;
-         u_valid(i, j) = 1;
+	 float theta = 1;
+	 if (liquid_phi(i, j) >= 0 || liquid_phi(i - 1, j) >= 0)
+	    theta = fraction_inside(liquid_phi(i - 1, j), liquid_phi(i, j));
+	 if (theta < 0.01f) theta = 0.01f;
+	 u(i, j) -= dt  * (float)(pressure[index] - pressure[index - 1]) / dx / theta;
+	 u_valid(i, j) = 1;
       }
       else
-         u(i, j) = 0;
+	 u(i, j) = 0;
    }
    v_valid.assign(0);
    for (int j = 1; j < v.nj - 1; ++j) for (int i = 0; i < v.ni; ++i) {
       int index = i + j*ni;
       if (v_weights(i, j) > 0 && (liquid_phi(i, j) < 0 || liquid_phi(i, j - 1) < 0)) {
-         float theta = 1;
-         if (liquid_phi(i, j) >= 0 || liquid_phi(i, j - 1) >= 0)
-            theta = fraction_inside(liquid_phi(i, j - 1), liquid_phi(i, j));
-         if (theta < 0.01f) theta = 0.01f;
-         v(i, j) -= dt  * (float)(pressure[index] - pressure[index - ni]) / dx / theta;
-         v_valid(i, j) = 1;
+	 float theta = 1;
+	 if (liquid_phi(i, j) >= 0 || liquid_phi(i, j - 1) >= 0)
+	    theta = fraction_inside(liquid_phi(i, j - 1), liquid_phi(i, j));
+	 if (theta < 0.01f) theta = 0.01f;
+	 v(i, j) -= dt  * (float)(pressure[index] - pressure[index - ni]) / dx / theta;
+	 v_valid(i, j) = 1;
       }
       else
-         v(i, j) = 0;
+	 v(i, j) = 0;
    }
 
    //Get pressure update to apply to solid
@@ -1212,14 +1212,14 @@ void FluidSim::solve_pressure_indefinite(float dt) {
    rbd->getAngularMomentum(updated_rigid_angular_momentum);
    for (int j = 0; j < nj; ++j) {
       for (int i = 0; i < ni; ++i) {
-         int index = i + ni*j;
-         float centre_phi = liquid_phi(i, j);
-         if (centre_phi < 0) {
-            updated_rigid_linear_velocity[0] += (float)(dt*base_trans_x(i, j)*pressure[index] / rigid_u_mass);
-            updated_rigid_linear_velocity[1] += (float)(dt*base_trans_y(i, j)*pressure[index] / rigid_v_mass);
+	 int index = i + ni*j;
+	 float centre_phi = liquid_phi(i, j);
+	 if (centre_phi < 0) {
+	    updated_rigid_linear_velocity[0] += (float)(dt*base_trans_x(i, j)*pressure[index] / rigid_u_mass);
+	    updated_rigid_linear_velocity[1] += (float)(dt*base_trans_y(i, j)*pressure[index] / rigid_v_mass);
 
-            updated_rigid_angular_momentum += (float)(dt*base_rot_z(i, j) * pressure[index]);
-         }
+	    updated_rigid_angular_momentum += (float)(dt*base_rot_z(i, j) * pressure[index]);
+	 }
       }
    }
 
@@ -1242,7 +1242,7 @@ void FluidSim::solve_viscosity(float dt) {
    int ni = liquid_phi.ni;
    int nj = liquid_phi.nj;
 
-   //static obstacles for simplicity - for moving objects, 
+   //static obstacles for simplicity - for moving objects,
    //use a spatially varying 2d array, and modify the linear system appropriately
    float u_obj = 0;
    float v_obj = 0;
@@ -1255,20 +1255,20 @@ void FluidSim::solve_viscosity(float dt) {
    //just determine if the face position is inside the wall! That's it.
    for (int j = 0; j < nj; ++j) {
       for (int i = 0; i < ni + 1; ++i) {
-         if (i - 1 < 0 || i >= ni || (nodal_solid_phi(i, j + 1) + nodal_solid_phi(i, j)) / 2 <= 0)
-            u_state(i, j) = SOLID;
-         else
-            u_state(i, j) = FLUID;
+	 if (i - 1 < 0 || i >= ni || (nodal_solid_phi(i, j + 1) + nodal_solid_phi(i, j)) / 2 <= 0)
+	    u_state(i, j) = SOLID;
+	 else
+	    u_state(i, j) = FLUID;
       }
    }
 
 
    for (int j = 0; j < nj + 1; ++j)  {
       for (int i = 0; i < ni; ++i) {
-         if (j - 1 < 0 || j >= nj || (nodal_solid_phi(i + 1, j) + nodal_solid_phi(i, j)) / 2 <= 0)
-            v_state(i, j) = SOLID;
-         else
-            v_state(i, j) = FLUID;
+	 if (j - 1 < 0 || j >= nj || (nodal_solid_phi(i + 1, j) + nodal_solid_phi(i, j)) / 2 <= 0)
+	    v_state(i, j) = SOLID;
+	 else
+	    v_state(i, j) = FLUID;
       }
    }
 
@@ -1283,73 +1283,73 @@ void FluidSim::solve_viscosity(float dt) {
    float factor = dt / sqr(dx);
    for (int j = 1; j < nj - 1; ++j) for (int i = 1; i < ni - 1; ++i) {
       if (u_state(i, j) == FLUID) {
-         int index = u_ind(i, j);
+	 int index = u_ind(i, j);
 
-         vrhs[index] = u_vol(i, j) * u(i, j);
-         vmatrix.set_element(index, index, u_vol(i, j));
+	 vrhs[index] = u_vol(i, j) * u(i, j);
+	 vmatrix.set_element(index, index, u_vol(i, j));
 
-         //uxx terms
-         float visc_right = viscosity(i, j);
-         float visc_left = viscosity(i - 1, j);
-         float vol_right = c_vol(i, j);
-         float vol_left = c_vol(i - 1, j);
+	 //uxx terms
+	 float visc_right = viscosity(i, j);
+	 float visc_left = viscosity(i - 1, j);
+	 float vol_right = c_vol(i, j);
+	 float vol_left = c_vol(i - 1, j);
 
-         //u_x_right
-         vmatrix.add_to_element(index, index, 2 * factor*visc_right*vol_right);
-         if (u_state(i + 1, j) == FLUID)
-            vmatrix.add_to_element(index, u_ind(i + 1, j), -2 * factor*visc_right*vol_right);
-         else if (u_state(i + 1, j) == SOLID)
-            vrhs[index] -= -2 * factor*visc_right*vol_right*u_obj;
+	 //u_x_right
+	 vmatrix.add_to_element(index, index, 2 * factor*visc_right*vol_right);
+	 if (u_state(i + 1, j) == FLUID)
+	    vmatrix.add_to_element(index, u_ind(i + 1, j), -2 * factor*visc_right*vol_right);
+	 else if (u_state(i + 1, j) == SOLID)
+	    vrhs[index] -= -2 * factor*visc_right*vol_right*u_obj;
 
-         //u_x_left
-         vmatrix.add_to_element(index, index, 2 * factor*visc_left*vol_left);
-         if (u_state(i - 1, j) == FLUID)
-            vmatrix.add_to_element(index, u_ind(i - 1, j), -2 * factor*visc_left*vol_left);
-         else if (u_state(i - 1, j) == SOLID)
-            vrhs[index] -= -2 * factor*visc_left*vol_left*u_obj;
+	 //u_x_left
+	 vmatrix.add_to_element(index, index, 2 * factor*visc_left*vol_left);
+	 if (u_state(i - 1, j) == FLUID)
+	    vmatrix.add_to_element(index, u_ind(i - 1, j), -2 * factor*visc_left*vol_left);
+	 else if (u_state(i - 1, j) == SOLID)
+	    vrhs[index] -= -2 * factor*visc_left*vol_left*u_obj;
 
-         //uyy terms
-         float visc_top = 0.25f*(viscosity(i - 1, j + 1) + viscosity(i - 1, j) + viscosity(i, j + 1) + viscosity(i, j));
-         float visc_bottom = 0.25f*(viscosity(i - 1, j) + viscosity(i - 1, j - 1) + viscosity(i, j) + viscosity(i, j - 1));
-         float vol_top = n_vol(i, j + 1);
-         float vol_bottom = n_vol(i, j);
+	 //uyy terms
+	 float visc_top = 0.25f*(viscosity(i - 1, j + 1) + viscosity(i - 1, j) + viscosity(i, j + 1) + viscosity(i, j));
+	 float visc_bottom = 0.25f*(viscosity(i - 1, j) + viscosity(i - 1, j - 1) + viscosity(i, j) + viscosity(i, j - 1));
+	 float vol_top = n_vol(i, j + 1);
+	 float vol_bottom = n_vol(i, j);
 
-         //u_y_top
-         vmatrix.add_to_element(index, index, +factor*visc_top*vol_top);
-         if (u_state(i, j + 1) == FLUID)
-            vmatrix.add_to_element(index, u_ind(i, j + 1), -factor*visc_top*vol_top);
-         else if (u_state(i, j + 1) == SOLID)
-            vrhs[index] -= -u_obj*factor*visc_top*vol_top;
+	 //u_y_top
+	 vmatrix.add_to_element(index, index, +factor*visc_top*vol_top);
+	 if (u_state(i, j + 1) == FLUID)
+	    vmatrix.add_to_element(index, u_ind(i, j + 1), -factor*visc_top*vol_top);
+	 else if (u_state(i, j + 1) == SOLID)
+	    vrhs[index] -= -u_obj*factor*visc_top*vol_top;
 
-         //u_y_bottom
-         vmatrix.add_to_element(index, index, +factor*visc_bottom*vol_bottom);
-         if (u_state(i, j - 1) == FLUID)
-            vmatrix.add_to_element(index, u_ind(i, j - 1), -factor*visc_bottom*vol_bottom);
-         else if (u_state(i, j - 1) == SOLID)
-            vrhs[index] -= -u_obj*factor*visc_bottom*vol_bottom;
+	 //u_y_bottom
+	 vmatrix.add_to_element(index, index, +factor*visc_bottom*vol_bottom);
+	 if (u_state(i, j - 1) == FLUID)
+	    vmatrix.add_to_element(index, u_ind(i, j - 1), -factor*visc_bottom*vol_bottom);
+	 else if (u_state(i, j - 1) == SOLID)
+	    vrhs[index] -= -u_obj*factor*visc_bottom*vol_bottom;
 
-         //vxy terms
-         //v_x_top
-         if (v_state(i, j + 1) == FLUID)
-            vmatrix.add_to_element(index, v_ind(i, j + 1), -factor*visc_top*vol_top);
-         else if (v_state(i, j + 1) == SOLID)
-            vrhs[index] -= -v_obj*factor*visc_top*vol_top;
+	 //vxy terms
+	 //v_x_top
+	 if (v_state(i, j + 1) == FLUID)
+	    vmatrix.add_to_element(index, v_ind(i, j + 1), -factor*visc_top*vol_top);
+	 else if (v_state(i, j + 1) == SOLID)
+	    vrhs[index] -= -v_obj*factor*visc_top*vol_top;
 
-         if (v_state(i - 1, j + 1) == FLUID)
-            vmatrix.add_to_element(index, v_ind(i - 1, j + 1), factor*visc_top*vol_top);
-         else if (v_state(i - 1, j + 1) == SOLID)
-            vrhs[index] -= v_obj*factor*visc_top*vol_top;
+	 if (v_state(i - 1, j + 1) == FLUID)
+	    vmatrix.add_to_element(index, v_ind(i - 1, j + 1), factor*visc_top*vol_top);
+	 else if (v_state(i - 1, j + 1) == SOLID)
+	    vrhs[index] -= v_obj*factor*visc_top*vol_top;
 
-         //v_x_bottom
-         if (v_state(i, j) == FLUID)
-            vmatrix.add_to_element(index, v_ind(i, j), +factor*visc_bottom*vol_bottom);
-         else if (v_state(i, j) == SOLID)
-            vrhs[index] -= v_obj*factor*visc_bottom*vol_bottom;
+	 //v_x_bottom
+	 if (v_state(i, j) == FLUID)
+	    vmatrix.add_to_element(index, v_ind(i, j), +factor*visc_bottom*vol_bottom);
+	 else if (v_state(i, j) == SOLID)
+	    vrhs[index] -= v_obj*factor*visc_bottom*vol_bottom;
 
-         if (v_state(i - 1, j) == FLUID)
-            vmatrix.add_to_element(index, v_ind(i - 1, j), -factor*visc_bottom*vol_bottom);
-         else if (v_state(i - 1, j) == SOLID)
-            vrhs[index] -= -v_obj*factor*visc_bottom*vol_bottom;
+	 if (v_state(i - 1, j) == FLUID)
+	    vmatrix.add_to_element(index, v_ind(i - 1, j), -factor*visc_bottom*vol_bottom);
+	 else if (v_state(i - 1, j) == SOLID)
+	    vrhs[index] -= -v_obj*factor*visc_bottom*vol_bottom;
 
 
       }
@@ -1357,74 +1357,74 @@ void FluidSim::solve_viscosity(float dt) {
 
    for (int j = 1; j < nj; ++j) for (int i = 1; i < ni - 1; ++i) {
       if (v_state(i, j) == FLUID) {
-         int index = v_ind(i, j);
+	 int index = v_ind(i, j);
 
-         vrhs[index] = v_vol(i, j)*v(i, j);
-         vmatrix.set_element(index, index, v_vol(i, j));
+	 vrhs[index] = v_vol(i, j)*v(i, j);
+	 vmatrix.set_element(index, index, v_vol(i, j));
 
-         //vyy
-         float visc_top = viscosity(i, j);
-         float visc_bottom = viscosity(i, j - 1);
-         float vol_top = c_vol(i, j);
-         float vol_bottom = c_vol(i, j - 1);
+	 //vyy
+	 float visc_top = viscosity(i, j);
+	 float visc_bottom = viscosity(i, j - 1);
+	 float vol_top = c_vol(i, j);
+	 float vol_bottom = c_vol(i, j - 1);
 
-         //vy_top
-         vmatrix.add_to_element(index, index, +2 * factor*visc_top*vol_top);
-         if (v_state(i, j + 1) == FLUID)
-            vmatrix.add_to_element(index, v_ind(i, j + 1), -2 * factor*visc_top*vol_top);
-         else if (v_state(i, j + 1) == SOLID)
-            vrhs[index] -= -2 * factor*visc_top*vol_top*v_obj;
+	 //vy_top
+	 vmatrix.add_to_element(index, index, +2 * factor*visc_top*vol_top);
+	 if (v_state(i, j + 1) == FLUID)
+	    vmatrix.add_to_element(index, v_ind(i, j + 1), -2 * factor*visc_top*vol_top);
+	 else if (v_state(i, j + 1) == SOLID)
+	    vrhs[index] -= -2 * factor*visc_top*vol_top*v_obj;
 
-         //vy_bottom
-         vmatrix.add_to_element(index, index, +2 * factor*visc_bottom*vol_bottom);
-         if (v_state(i, j - 1) == FLUID)
-            vmatrix.add_to_element(index, v_ind(i, j - 1), -2 * factor*visc_bottom*vol_bottom);
-         else if (v_state(i, j - 1) == SOLID)
-            vrhs[index] -= -2 * factor*visc_bottom*vol_bottom*v_obj;
+	 //vy_bottom
+	 vmatrix.add_to_element(index, index, +2 * factor*visc_bottom*vol_bottom);
+	 if (v_state(i, j - 1) == FLUID)
+	    vmatrix.add_to_element(index, v_ind(i, j - 1), -2 * factor*visc_bottom*vol_bottom);
+	 else if (v_state(i, j - 1) == SOLID)
+	    vrhs[index] -= -2 * factor*visc_bottom*vol_bottom*v_obj;
 
-         //vxx terms
-         float visc_right = 0.25f*(viscosity(i, j - 1) + viscosity(i + 1, j - 1) + viscosity(i, j) + viscosity(i + 1, j));
-         float visc_left = 0.25f*(viscosity(i, j - 1) + viscosity(i - 1, j - 1) + viscosity(i, j) + viscosity(i - 1, j));
-         float vol_right = n_vol(i + 1, j);
-         float vol_left = n_vol(i, j);
+	 //vxx terms
+	 float visc_right = 0.25f*(viscosity(i, j - 1) + viscosity(i + 1, j - 1) + viscosity(i, j) + viscosity(i + 1, j));
+	 float visc_left = 0.25f*(viscosity(i, j - 1) + viscosity(i - 1, j - 1) + viscosity(i, j) + viscosity(i - 1, j));
+	 float vol_right = n_vol(i + 1, j);
+	 float vol_left = n_vol(i, j);
 
-         //v_x_right
-         vmatrix.add_to_element(index, index, +factor*visc_right*vol_right);
-         if (v_state(i + 1, j) == FLUID)
-            vmatrix.add_to_element(index, v_ind(i + 1, j), -factor*visc_right*vol_right);
-         else if (v_state(i + 1, j) == SOLID)
-            vrhs[index] -= -v_obj*factor*visc_right*vol_right;
+	 //v_x_right
+	 vmatrix.add_to_element(index, index, +factor*visc_right*vol_right);
+	 if (v_state(i + 1, j) == FLUID)
+	    vmatrix.add_to_element(index, v_ind(i + 1, j), -factor*visc_right*vol_right);
+	 else if (v_state(i + 1, j) == SOLID)
+	    vrhs[index] -= -v_obj*factor*visc_right*vol_right;
 
-         //v_x_left
-         vmatrix.add_to_element(index, index, +factor*visc_left*vol_left);
-         if (v_state(i - 1, j) == FLUID)
-            vmatrix.add_to_element(index, v_ind(i - 1, j), -factor*visc_left*vol_left);
-         else if (v_state(i - 1, j) == SOLID)
-            vrhs[index] -= -v_obj*factor*visc_left*vol_left;
+	 //v_x_left
+	 vmatrix.add_to_element(index, index, +factor*visc_left*vol_left);
+	 if (v_state(i - 1, j) == FLUID)
+	    vmatrix.add_to_element(index, v_ind(i - 1, j), -factor*visc_left*vol_left);
+	 else if (v_state(i - 1, j) == SOLID)
+	    vrhs[index] -= -v_obj*factor*visc_left*vol_left;
 
-         //uyx
+	 //uyx
 
-         //u_y_right
-         if (u_state(i + 1, j) == FLUID)
-            vmatrix.add_to_element(index, u_ind(i + 1, j), -factor*visc_right*vol_right);
-         else if (u_state(i + 1, j) == SOLID)
-            vrhs[index] -= -u_obj*factor*visc_right*vol_right;
+	 //u_y_right
+	 if (u_state(i + 1, j) == FLUID)
+	    vmatrix.add_to_element(index, u_ind(i + 1, j), -factor*visc_right*vol_right);
+	 else if (u_state(i + 1, j) == SOLID)
+	    vrhs[index] -= -u_obj*factor*visc_right*vol_right;
 
-         if (u_state(i + 1, j - 1) == FLUID)
-            vmatrix.add_to_element(index, u_ind(i + 1, j - 1), factor*visc_right*vol_right);
-         else if (u_state(i + 1, j - 1) == SOLID)
-            vrhs[index] -= u_obj*factor*visc_right*vol_right;
+	 if (u_state(i + 1, j - 1) == FLUID)
+	    vmatrix.add_to_element(index, u_ind(i + 1, j - 1), factor*visc_right*vol_right);
+	 else if (u_state(i + 1, j - 1) == SOLID)
+	    vrhs[index] -= u_obj*factor*visc_right*vol_right;
 
-         //u_y_left
-         if (u_state(i, j) == FLUID)
-            vmatrix.add_to_element(index, u_ind(i, j), factor*visc_left*vol_left);
-         else if (u_state(i, j) == SOLID)
-            vrhs[index] -= u_obj*factor*visc_left*vol_left;
+	 //u_y_left
+	 if (u_state(i, j) == FLUID)
+	    vmatrix.add_to_element(index, u_ind(i, j), factor*visc_left*vol_left);
+	 else if (u_state(i, j) == SOLID)
+	    vrhs[index] -= u_obj*factor*visc_left*vol_left;
 
-         if (u_state(i, j - 1) == FLUID)
-            vmatrix.add_to_element(index, u_ind(i, j - 1), -factor*visc_left*vol_left);
-         else if (u_state(i, j - 1) == SOLID)
-            vrhs[index] -= -u_obj*factor*visc_left*vol_left;
+	 if (u_state(i, j - 1) == FLUID)
+	    vmatrix.add_to_element(index, u_ind(i, j - 1), -factor*visc_left*vol_left);
+	 else if (u_state(i, j - 1) == SOLID)
+	    vrhs[index] -= -u_obj*factor*visc_left*vol_left;
 
       }
    }
@@ -1463,36 +1463,36 @@ void extrapolate(Array2f& grid, Array2c& valid) {
       old_valid = valid;
       Array2f temp_grid = grid;
       for (int j = 1; j < grid.nj - 1; ++j) for (int i = 1; i < grid.ni - 1; ++i) {
-         float sum = 0;
-         int count = 0;
+	 float sum = 0;
+	 int count = 0;
 
-         if (!old_valid(i, j)) {
+	 if (!old_valid(i, j)) {
 
-            if (old_valid(i + 1, j)) {
-               sum += grid(i + 1, j); \
-                  ++count;
-            }
-            if (old_valid(i - 1, j)) {
-               sum += grid(i - 1, j); \
-                  ++count;
-            }
-            if (old_valid(i, j + 1)) {
-               sum += grid(i, j + 1); \
-                  ++count;
-            }
-            if (old_valid(i, j - 1)) {
-               sum += grid(i, j - 1); \
-                  ++count;
-            }
+	    if (old_valid(i + 1, j)) {
+	       sum += grid(i + 1, j); \
+		  ++count;
+	    }
+	    if (old_valid(i - 1, j)) {
+	       sum += grid(i - 1, j); \
+		  ++count;
+	    }
+	    if (old_valid(i, j + 1)) {
+	       sum += grid(i, j + 1); \
+		  ++count;
+	    }
+	    if (old_valid(i, j - 1)) {
+	       sum += grid(i, j - 1); \
+		  ++count;
+	    }
 
-            //If any of neighbour cells were valid, 
-            //assign the cell their average value and tag it as valid
-            if (count > 0) {
-               temp_grid(i, j) = sum / (float)count;
-               valid(i, j) = 1;
-            }
+	    //If any of neighbour cells were valid,
+	    //assign the cell their average value and tag it as valid
+	    if (count > 0) {
+	       temp_grid(i, j) = sum / (float)count;
+	       valid(i, j) = 1;
+	    }
 
-         }
+	 }
       }
       grid = temp_grid;
 

--- a/mat.h
+++ b/mat.h
@@ -1,7 +1,8 @@
 #ifndef MAT_H
 #define MAT_H
- 
+
 #include "vec.h"
+#include <cstring>
 
 template<unsigned int M, unsigned int N, class T>
 struct Mat
@@ -125,12 +126,12 @@ struct Mat
       const T *pa, *pv;
       T s, *pr=r.v;
       for(i=0; i<M; ++i, ++pr){
-         pa=a+i;
-         pv=v.v;
-         s=0;
-         for(j=0; j<N; ++j, pa+=M, ++pv)
-            s+=*pa*(*pv);
-         *pr=s;
+	 pa=a+i;
+	 pv=v.v;
+	 s=0;
+	 for(j=0; j<N; ++j, pa+=M, ++pv)
+	    s+=*pa*(*pv);
+	 *pr=s;
       }
 	  return r;
    }
@@ -143,14 +144,14 @@ struct Mat
       const T *pa, *pb;
       T s, *pc=c.a;
       for(k=0; k<P; ++k){
-         for(i=0; i<M; ++i, ++pc){
-            pa=a+i;
-            pb=b.a+N*k;
-            s=0;
-            for(j=0; j<N; ++j, pa+=M, ++pb)
-               s+=*pa*(*pb);
-            *pc=s;
-         }
+	 for(i=0; i<M; ++i, ++pc){
+	    pa=a+i;
+	    pb=b.a+N*k;
+	    s=0;
+	    for(j=0; j<N; ++j, pa+=M, ++pb)
+	       s+=*pa*(*pb);
+	    *pc=s;
+	 }
       }
 	  return c;
    }
@@ -170,11 +171,11 @@ struct Mat
 
    Mat<N,M,T> transpose() const {
       Mat<N,M,T> result;
-      
+
       for(unsigned int i = 0; i < M; ++i) {
-         for(unsigned int j = 0; j < N; ++j) {
-            result(j,i) = (*this)(i,j);
-         }
+	 for(unsigned int j = 0; j < N; ++j) {
+	    result(j,i) = (*this)(i,j);
+	 }
       }
       return result;
    }
@@ -203,7 +204,7 @@ std::ostream &operator<<(std::ostream &out, const Mat<M,N,T> &a)
    for(unsigned int i=0; i<M; ++i){
       out<<(i==0 ? '[' : ' ');
       for(unsigned int j=0; j<N-1; ++j)
-         out<<a(i,j)<<',';
+	 out<<a(i,j)<<',';
       out<<a(i,N-1);
       if(i<M-1) out<<';'<<std::endl;
       else out<<']';
@@ -226,7 +227,7 @@ inline Mat<M,N,T> outer(const Vec<M,T> &x, const Vec<N,T> &y)
    T *pr=r.a;
    for(unsigned int j=0; j<N; ++j)
       for(unsigned int i=0; i<M; ++i, ++pr)
-         *pr=x[i]*y[j];
+	 *pr=x[i]*y[j];
    return r;
 }
 
@@ -248,8 +249,8 @@ template<class T>
 inline Mat<3,3,T> star_matrix(const Vec<3,T> &w)
 {
    return Mat<3,3,T>(0, -w.v[2], w.v[1],
-                     w.v[2], 0, -w.v[0],
-                     -w.v[1], w.v[0], 0);
+		     w.v[2], 0, -w.v[0],
+		     -w.v[1], w.v[0], 0);
 }
 
 #endif

--- a/pcgsolver/sparse_matrix.h
+++ b/pcgsolver/sparse_matrix.h
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <vector>
-#include "util.h"
+#include "../util.h"
 
 //============================================================================
 // Dynamic compressed sparse row matrix.
@@ -19,8 +19,8 @@ struct SparseMatrix
       : n(n_), index(n_), value(n_)
    {
       for(unsigned int i=0; i<n; ++i){
-         index[i].reserve(expected_nonzeros_per_row);
-         value[i].reserve(expected_nonzeros_per_row);
+	 index[i].reserve(expected_nonzeros_per_row);
+	 value[i].reserve(expected_nonzeros_per_row);
       }
    }
 
@@ -34,8 +34,8 @@ struct SparseMatrix
    void zero(void)
    {
       for(unsigned int i=0; i<n; ++i){
-         index[i].resize(0);
-         value[i].resize(0);
+	 index[i].resize(0);
+	 value[i].resize(0);
       }
    }
 
@@ -49,8 +49,8 @@ struct SparseMatrix
    T operator()(unsigned int i, unsigned int j) const
    {
       for(unsigned int k=0; k<index[i].size(); ++k){
-         if(index[i][k]==j) return value[i][k];
-         else if(index[i][k]>j) return 0;
+	 if(index[i][k]==j) return value[i][k];
+	 else if(index[i][k]>j) return 0;
       }
       return 0;
    }
@@ -59,14 +59,14 @@ struct SparseMatrix
    {
       unsigned int k=0;
       for(; k<index[i].size(); ++k){
-         if(index[i][k]==j){
-            value[i][k]=new_value;
-            return;
-         }else if(index[i][k]>j){
-            insert(index[i], k, j);
-            insert(value[i], k, new_value);
-            return;
-         }
+	 if(index[i][k]==j){
+	    value[i][k]=new_value;
+	    return;
+	 }else if(index[i][k]>j){
+	    insert(index[i], k, j);
+	    insert(value[i], k, new_value);
+	    return;
+	 }
       }
       index[i].push_back(j);
       value[i].push_back(new_value);
@@ -76,14 +76,14 @@ struct SparseMatrix
    {
       unsigned int k=0;
       for(; k<index[i].size(); ++k){
-         if(index[i][k]==j){
-            value[i][k]+=increment_value;
-            return;
-         }else if(index[i][k]>j){
-            insert(index[i], k, j);
-            insert(value[i], k, increment_value);
-            return;
-         }
+	 if(index[i][k]==j){
+	    value[i][k]+=increment_value;
+	    return;
+	 }else if(index[i][k]>j){
+	    insert(index[i], k, j);
+	    insert(value[i], k, increment_value);
+	    return;
+	 }
       }
       index[i].push_back(j);
       value[i].push_back(increment_value);
@@ -94,21 +94,21 @@ struct SparseMatrix
    {
       unsigned int j=0, k=0;
       while(j<indices.size() && k<index[i].size()){
-         if(index[i][k]<indices[j]){
-            ++k;
-         }else if(index[i][k]>indices[j]){
-            insert(index[i], k, indices[j]);
-            insert(value[i], k, values[j]);
-            ++j;
-         }else{
-            value[i][k]+=values[j];
-            ++j;
-            ++k;
-         }
+	 if(index[i][k]<indices[j]){
+	    ++k;
+	 }else if(index[i][k]>indices[j]){
+	    insert(index[i], k, indices[j]);
+	    insert(value[i], k, values[j]);
+	    ++j;
+	 }else{
+	    value[i][k]+=values[j];
+	    ++j;
+	    ++k;
+	 }
       }
       for(;j<indices.size(); ++j){
-         index[i].push_back(indices[j]);
-         value[i].push_back(values[j]);
+	 index[i].push_back(indices[j]);
+	 value[i].push_back(values[j]);
       }
    }
 
@@ -116,14 +116,14 @@ struct SparseMatrix
    void symmetric_remove_row_and_column(unsigned int i)
    {
       for(unsigned int a=0; a<index[i].size(); ++a){
-         unsigned int j=index[i][a]; // 
-         for(unsigned int b=0; b<index[j].size(); ++b){
-            if(index[j][b]==i){
-               erase(index[j], b);
-               erase(value[j], b);
-               break;
-            }
-         }
+	 unsigned int j=index[i][a]; //
+	 for(unsigned int b=0; b<index[j].size(); ++b){
+	    if(index[j][b]==i){
+	       erase(index[j], b);
+	       erase(value[j], b);
+	       break;
+	    }
+	 }
       }
       index[i].resize(0);
       value[i].resize(0);
@@ -133,21 +133,21 @@ struct SparseMatrix
    {
       output<<variable_name<<"=sparse([";
       for(unsigned int i=0; i<n; ++i){
-         for(unsigned int j=0; j<index[i].size(); ++j){
-            output<<i+1<<" ";
-         }
+	 for(unsigned int j=0; j<index[i].size(); ++j){
+	    output<<i+1<<" ";
+	 }
       }
       output<<"],...\n  [";
       for(unsigned int i=0; i<n; ++i){
-         for(unsigned int j=0; j<index[i].size(); ++j){
-            output<<index[i][j]+1<<" ";
-         }
+	 for(unsigned int j=0; j<index[i].size(); ++j){
+	    output<<index[i][j]+1<<" ";
+	 }
       }
       output<<"],...\n  [";
       for(unsigned int i=0; i<n; ++i){
-         for(unsigned int j=0; j<value[i].size(); ++j){
-            output<<value[i][j]<<" ";
-         }
+	 for(unsigned int j=0; j<value[i].size(); ++j){
+	    output<<value[i][j]<<" ";
+	 }
       }
       output<<"], "<<n<<", "<<n<<");"<<std::endl;
    }
@@ -165,7 +165,7 @@ void multiply(const SparseMatrix<T> &matrix, const std::vector<T> &x, std::vecto
    for(unsigned int i=0; i<matrix.n; ++i){
       result[i]=0;
       for(unsigned int j=0; j<matrix.index[i].size(); ++j){
-         result[i]+=matrix.value[i][j]*x[matrix.index[i][j]];
+	 result[i]+=matrix.value[i][j]*x[matrix.index[i][j]];
       }
    }
 }
@@ -178,7 +178,7 @@ void multiply_and_subtract(const SparseMatrix<T> &matrix, const std::vector<T> &
    result.resize(matrix.n);
    for(unsigned int i=0; i<matrix.n; ++i){
       for(unsigned int j=0; j<matrix.index[i].size(); ++j){
-         result[i]-=matrix.value[i][j]*x[matrix.index[i][j]];
+	 result[i]-=matrix.value[i][j]*x[matrix.index[i][j]];
       }
    }
 }
@@ -219,17 +219,17 @@ struct FixedSparseMatrix
       resize(matrix.n);
       rowstart[0]=0;
       for(unsigned int i=0; i<n; ++i){
-         rowstart[i+1]=rowstart[i]+(unsigned int)matrix.index[i].size();
+	 rowstart[i+1]=rowstart[i]+(unsigned int)matrix.index[i].size();
       }
       value.resize(rowstart[n]);
       colindex.resize(rowstart[n]);
       unsigned int j=0;
       for(unsigned int i=0; i<n; ++i){
-         for(unsigned int k=0; k<matrix.index[i].size(); ++k){
-            value[j]=matrix.value[i][k];
-            colindex[j]=matrix.index[i][k];
-            ++j;
-         }
+	 for(unsigned int k=0; k<matrix.index[i].size(); ++k){
+	    value[j]=matrix.value[i][k];
+	    colindex[j]=matrix.index[i][k];
+	    ++j;
+	 }
       }
    }
 
@@ -237,21 +237,21 @@ struct FixedSparseMatrix
    {
       output<<variable_name<<"=sparse([";
       for(unsigned int i=0; i<n; ++i){
-         for(unsigned int j=rowstart[i]; j<rowstart[i+1]; ++j){
-            output<<i+1<<" ";
-         }
+	 for(unsigned int j=rowstart[i]; j<rowstart[i+1]; ++j){
+	    output<<i+1<<" ";
+	 }
       }
       output<<"],...\n  [";
       for(unsigned int i=0; i<n; ++i){
-         for(unsigned int j=rowstart[i]; j<rowstart[i+1]; ++j){
-            output<<colindex[j]+1<<" ";
-         }
+	 for(unsigned int j=rowstart[i]; j<rowstart[i+1]; ++j){
+	    output<<colindex[j]+1<<" ";
+	 }
       }
       output<<"],...\n  [";
       for(unsigned int i=0; i<n; ++i){
-         for(unsigned int j=rowstart[i]; j<rowstart[i+1]; ++j){
-            output<<value[j]<<" ";
-         }
+	 for(unsigned int j=rowstart[i]; j<rowstart[i+1]; ++j){
+	    output<<value[j]<<" ";
+	 }
       }
       output<<"], "<<n<<", "<<n<<");"<<std::endl;
    }
@@ -269,7 +269,7 @@ void multiply(const FixedSparseMatrix<T> &matrix, const std::vector<T> &x, std::
    for(unsigned int i=0; i<matrix.n; ++i){
       result[i]=0;
       for(unsigned int j=matrix.rowstart[i]; j<matrix.rowstart[i+1]; ++j){
-         result[i]+=matrix.value[j]*x[matrix.colindex[j]];
+	 result[i]+=matrix.value[j]*x[matrix.colindex[j]];
       }
    }
 }
@@ -282,7 +282,7 @@ void multiply_and_subtract(const FixedSparseMatrix<T> &matrix, const std::vector
    result.resize(matrix.n);
    for(unsigned int i=0; i<matrix.n; ++i){
       for(unsigned int j=matrix.rowstart[i]; j<matrix.rowstart[i+1]; ++j){
-         result[i]-=matrix.value[j]*x[matrix.colindex[j]];
+	 result[i]-=matrix.value[j]*x[matrix.colindex[j]];
       }
    }
 }

--- a/util.h
+++ b/util.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <cmath>
 #include <iostream>
+#include <climits>
 
 #ifndef M_PI
 const double M_PI = 3.1415926535897932384626433832795;
@@ -76,22 +77,22 @@ inline void minmax(T a1, T a2, T a3, T& amin, T& amax)
 {
    if(a1<a2){
       if(a1<a3){
-         amin=a1;
-         if(a2<a3) amax=a3;
-         else amax=a2;
+	 amin=a1;
+	 if(a2<a3) amax=a3;
+	 else amax=a2;
       }else{
-         amin=a3;
-         if(a1<a2) amax=a2;
-         else amax=a1;
+	 amin=a3;
+	 if(a1<a2) amax=a2;
+	 else amax=a1;
       }
    }else{
       if(a2<a3){
-         amin=a2;
-         if(a1<a3) amax=a3;
-         else amax=a1;
+	 amin=a2;
+	 if(a1<a3) amax=a3;
+	 else amax=a1;
       }else{
-         amin=a3;
-         amax=a1;
+	 amin=a3;
+	 amax=a1;
       }
    }
 }
@@ -101,19 +102,19 @@ inline void minmax(T a1, T a2, T a3, T a4, T& amin, T& amax)
 {
    if(a1<a2){
       if(a3<a4){
-         amin=min(a1,a3);
-         amax=max(a2,a4);
+	 amin=min(a1,a3);
+	 amax=max(a2,a4);
       }else{
-         amin=min(a1,a4);
-         amax=max(a2,a3);
+	 amin=min(a1,a4);
+	 amax=max(a2,a3);
       }
    }else{
       if(a3<a4){
-         amin=min(a2,a3);
-         amax=max(a1,a4);
+	 amin=min(a2,a3);
+	 amax=max(a1,a4);
       }else{
-         amin=min(a2,a4);
-         amax=max(a1,a3);
+	 amin=min(a2,a4);
+	 amax=max(a1,a3);
       }
    }
 }
@@ -148,7 +149,7 @@ inline void sort(T &a, T &b, T &c)
    if(a<b){
       if(a<c){
     if(c<b){ // a<c<b
-            temp=c;c=b;b=temp;
+	    temp=c;c=b;b=temp;
     } // else: a<b<c
       }else{ // c<a<b
     temp=c;c=b;b=a;a=temp;
@@ -222,7 +223,7 @@ inline unsigned int round_down_to_power_of_two(unsigned int n)
    return 1<<exponent;
 }
 
-// Transforms even the sequence 0,1,2,3,... into reasonably good random numbers 
+// Transforms even the sequence 0,1,2,3,... into reasonably good random numbers
 // Challenge: improve on this in speed and "randomness"!
 // This seems to pass several statistical tests, and is a bijective map (of 32-bit unsigned ints)
 inline unsigned int randhash(unsigned int seed)
@@ -289,41 +290,41 @@ inline S lerp(const S& value0, const S& value1, T f)
 { return (1-f)*value0 + f*value1; }
 
 template<class S, class T>
-inline S bilerp(const S& v00, const S& v10, 
-                const S& v01, const S& v11, 
-                T fx, T fy)
-{ 
+inline S bilerp(const S& v00, const S& v10,
+		const S& v01, const S& v11,
+		T fx, T fy)
+{
    return lerp(lerp(v00, v10, fx),
-               lerp(v01, v11, fx), 
-               fy);
+	       lerp(v01, v11, fx),
+	       fy);
 }
 
 template<class S, class T>
 inline S trilerp(const S& v000, const S& v100,
-                 const S& v010, const S& v110,
-                 const S& v001, const S& v101,  
-                 const S& v011, const S& v111,
-                 T fx, T fy, T fz) 
+		 const S& v010, const S& v110,
+		 const S& v001, const S& v101,
+		 const S& v011, const S& v111,
+		 T fx, T fy, T fz)
 {
    return lerp(bilerp(v000, v100, v010, v110, fx, fy),
-               bilerp(v001, v101, v011, v111, fx, fy),
-               fz);
+	       bilerp(v001, v101, v011, v111, fx, fy),
+	       fz);
 }
 
 template<class S, class T>
 inline S quadlerp(const S& v0000, const S& v1000,
-                  const S& v0100, const S& v1100,
-                  const S& v0010, const S& v1010,  
-                  const S& v0110, const S& v1110,
-                  const S& v0001, const S& v1001,
-                  const S& v0101, const S& v1101,
-                  const S& v0011, const S& v1011,  
-                  const S& v0111, const S& v1111,
-                  T fx, T fy, T fz, T ft) 
+		  const S& v0100, const S& v1100,
+		  const S& v0010, const S& v1010,
+		  const S& v0110, const S& v1110,
+		  const S& v0001, const S& v1001,
+		  const S& v0101, const S& v1101,
+		  const S& v0011, const S& v1011,
+		  const S& v0111, const S& v1111,
+		  T fx, T fy, T fz, T ft)
 {
    return lerp(trilerp(v0000, v1000, v0100, v1100, v0010, v1010, v0110, v1110, fx, fy, fz),
-               trilerp(v0001, v1001, v0101, v1101, v0011, v1011, v0111, v1111, fx, fy, fz),
-               ft);
+	       trilerp(v0001, v1001, v0101, v1101, v0011, v1011, v0111, v1111, fx, fy, fz),
+	       ft);
 }
 
 // f should be between 0 and 1, with f=0.5 corresponding to balanced weighting between w0 and w2
@@ -364,7 +365,7 @@ T abs_max(const std::vector<T>& v)
    T m=0;
    for(int i=(int)v.size()-1; i>=0; --i){
       if(std::fabs(v[i])>m)
-         m=std::fabs(v[i]);
+	 m=std::fabs(v[i]);
    }
    return m;
 }
@@ -429,8 +430,8 @@ void find_and_erase_unordered(std::vector<T>& a, const T& doomed_element)
 {
    for(unsigned int i=0; i<a.size(); ++i)
       if(a[i]==doomed_element){
-         erase_unordered(a, i);
-         return;
+	 erase_unordered(a, i);
+	 return;
       }
 }
 
@@ -439,8 +440,8 @@ void replace_once(std::vector<T>& a, const T& old_element, const T& new_element)
 {
    for(unsigned int i=0; i<a.size(); ++i)
       if(a[i]==old_element){
-         a[i]=new_element;
-         return;
+	 a[i]=new_element;
+	 return;
       }
 }
 


### PR DESCRIPTION
Most changes are related to missing includes in Linux, and a few were non-standard constructs that GCC complains about. I also changed double >> templates into > > so that it compiles in C++ < 11.
I've added an extremely basic Makefile in the RigidFluids directory, which assumes eigen3 to be in the default directory (Ubuntu)
Sorry but there are a lot of indentation changes and I don't know how to undo them. It seems the original files had a mix of spaces and tabs, and my editor was confused by it.